### PR TITLE
feat: add compressed save transfer menu

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,6 @@
 import { startTransition, useEffect } from "react";
 import { useShallow } from "zustand/react/shallow";
+import { SaveTransferMenu } from "./components/SaveTransferMenu";
 import { RECIPES } from "./data/gameData";
 import { getDiscoveryProgressPercent } from "./lib/gameLogic";
 import { useNow } from "./lib/useNow";
@@ -130,6 +131,8 @@ export default function App() {
                   ))}
                 </select>
               </label>
+
+              <SaveTransferMenu />
             </div>
           </div>
         </header>

--- a/src/components/SaveTransferMenu.tsx
+++ b/src/components/SaveTransferMenu.tsx
@@ -1,0 +1,490 @@
+import { startTransition, useEffect, useRef, useState } from "react";
+import type { CSSProperties } from "react";
+import { useShallow } from "zustand/react/shallow";
+import { exportGameState, importGameState } from "../lib/gameState";
+import { useGameStore } from "../store/gameStore";
+import type { GameState } from "../types/game";
+
+type StatusTone = "info" | "success" | "error";
+type StatusState = { message: string; tone: StatusTone };
+type ActiveModal = "export" | "import" | null;
+
+const menuWrapperStyle: CSSProperties = {
+  position: "relative",
+  display: "grid",
+  gap: 10,
+};
+
+const triggerStyle: CSSProperties = {
+  width: "fit-content",
+  justifySelf: "start",
+};
+
+const menuPanelStyle: CSSProperties = {
+  position: "absolute",
+  top: "calc(100% + 12px)",
+  right: 0,
+  width: "min(320px, calc(100vw - 48px))",
+  maxWidth: "calc(100vw - 48px)",
+  padding: 18,
+  border: "2px solid rgba(239, 154, 189, 0.72)",
+  borderRadius: 24,
+  background: "linear-gradient(180deg, rgba(255, 255, 255, 0.96), rgba(255, 246, 251, 0.94))",
+  boxShadow: "0 22px 36px rgba(171, 79, 117, 0.18)",
+  display: "grid",
+  gap: 12,
+  zIndex: 20,
+};
+
+const menuActionsStyle: CSSProperties = {
+  display: "grid",
+  gap: 10,
+};
+
+const menuTextStyle: CSSProperties = {
+  color: "var(--text-soft)",
+  fontSize: "0.94rem",
+};
+
+const overlayStyle: CSSProperties = {
+  position: "fixed",
+  inset: 0,
+  zIndex: 40,
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "center",
+  padding: 16,
+  background: "rgba(78, 35, 55, 0.34)",
+  backdropFilter: "blur(8px)",
+};
+
+const modalPanelStyle: CSSProperties = {
+  width: "min(560px, calc(100vw - 32px))",
+  maxHeight: "calc(100vh - 32px)",
+  margin: 0,
+  overflow: "auto",
+};
+
+const modalHeaderStyle: CSSProperties = {
+  display: "flex",
+  alignItems: "flex-start",
+  justifyContent: "space-between",
+  gap: 12,
+  flexWrap: "wrap",
+};
+
+const modalBodyStyle: CSSProperties = {
+  display: "grid",
+  gap: 14,
+  marginTop: 18,
+};
+
+const modalActionsStyle: CSSProperties = {
+  display: "flex",
+  justifyContent: "flex-end",
+  gap: 12,
+  flexWrap: "wrap",
+};
+
+const textAreaStyle: CSSProperties = {
+  width: "100%",
+  minHeight: 168,
+  padding: "14px 16px",
+  border: "2px solid rgba(239, 154, 189, 0.72)",
+  borderRadius: 22,
+  background: "rgba(255, 252, 254, 0.96)",
+  color: "var(--text)",
+  lineHeight: 1.5,
+  resize: "vertical",
+};
+
+const warningStyle: CSSProperties = {
+  padding: "12px 14px",
+  borderRadius: 18,
+  border: "2px dashed rgba(239, 154, 189, 0.7)",
+  background: "rgba(255, 242, 248, 0.88)",
+  color: "var(--text-soft)",
+  fontWeight: 700,
+  lineHeight: 1.5,
+};
+
+function getStatusStyle(tone: StatusTone): CSSProperties {
+  if (tone === "error") {
+    return {
+      borderStyle: "solid",
+      borderColor: "rgba(201, 89, 89, 0.34)",
+      background: "rgba(255, 238, 240, 0.94)",
+      color: "#9a3d4d",
+    };
+  }
+
+  if (tone === "success") {
+    return {
+      borderStyle: "solid",
+      borderColor: "rgba(102, 181, 138, 0.34)",
+      background: "rgba(241, 255, 247, 0.94)",
+      color: "#2b7d54",
+    };
+  }
+
+  return {
+    borderStyle: "solid",
+  };
+}
+
+function getErrorMessage(error: unknown, fallback: string) {
+  if (error instanceof Error && error.message) {
+    return error.message;
+  }
+
+  return fallback;
+}
+
+export function SaveTransferMenu() {
+  const menuRef = useRef<HTMLDivElement | null>(null);
+  const exportTextareaRef = useRef<HTMLTextAreaElement | null>(null);
+  const importTextareaRef = useRef<HTMLTextAreaElement | null>(null);
+  const [menuOpen, setMenuOpen] = useState(false);
+  const [activeModal, setActiveModal] = useState<ActiveModal>(null);
+  const [exportValue, setExportValue] = useState("");
+  const [importValue, setImportValue] = useState("");
+  const [exportStatus, setExportStatus] = useState<StatusState>({ message: "", tone: "info" });
+  const [importStatus, setImportStatus] = useState<StatusState>({ message: "", tone: "info" });
+
+  const {
+    inventory,
+    selection,
+    discoveredRecipeIds,
+    collection,
+    favorites,
+    pendingBoxes,
+    lastDeliveryResolvedAt,
+    lastDailyClaimDate,
+    dailyStreak,
+    lastDailyChallengeDate,
+    lastCraftedRecipeId,
+    replaceGameState,
+  } = useGameStore(
+    useShallow((state) => ({
+      inventory: state.inventory,
+      selection: state.selection,
+      discoveredRecipeIds: state.discoveredRecipeIds,
+      collection: state.collection,
+      favorites: state.favorites,
+      pendingBoxes: state.pendingBoxes,
+      lastDeliveryResolvedAt: state.lastDeliveryResolvedAt,
+      lastDailyClaimDate: state.lastDailyClaimDate,
+      dailyStreak: state.dailyStreak,
+      lastDailyChallengeDate: state.lastDailyChallengeDate,
+      lastCraftedRecipeId: state.lastCraftedRecipeId,
+      replaceGameState: state.replaceGameState,
+    })),
+  );
+
+  useEffect(() => {
+    if (!menuOpen) {
+      return;
+    }
+
+    function handlePointerDown(event: PointerEvent) {
+      if (menuRef.current?.contains(event.target as Node)) {
+        return;
+      }
+
+      setMenuOpen(false);
+    }
+
+    function handleKeyDown(event: KeyboardEvent) {
+      if (event.key === "Escape") {
+        setMenuOpen(false);
+      }
+    }
+
+    document.addEventListener("pointerdown", handlePointerDown);
+    document.addEventListener("keydown", handleKeyDown);
+
+    return () => {
+      document.removeEventListener("pointerdown", handlePointerDown);
+      document.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [menuOpen]);
+
+  useEffect(() => {
+    if (!activeModal) {
+      return;
+    }
+
+    function handleKeyDown(event: KeyboardEvent) {
+      if (event.key === "Escape") {
+        setActiveModal(null);
+      }
+    }
+
+    document.addEventListener("keydown", handleKeyDown);
+    return () => {
+      document.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [activeModal]);
+
+  useEffect(() => {
+    if (activeModal !== "import") {
+      return;
+    }
+
+    const timer = window.setTimeout(() => {
+      importTextareaRef.current?.focus();
+    }, 0);
+
+    return () => {
+      window.clearTimeout(timer);
+    };
+  }, [activeModal]);
+
+  useEffect(() => {
+    if (activeModal !== "export" || !exportValue) {
+      return;
+    }
+
+    const timer = window.setTimeout(() => {
+      exportTextareaRef.current?.focus();
+      exportTextareaRef.current?.select();
+    }, 0);
+
+    return () => {
+      window.clearTimeout(timer);
+    };
+  }, [activeModal, exportValue]);
+
+  function createSnapshot(): GameState {
+    return {
+      inventory,
+      selection,
+      discoveredRecipeIds,
+      collection,
+      favorites,
+      pendingBoxes,
+      lastDeliveryResolvedAt,
+      lastDailyClaimDate,
+      dailyStreak,
+      lastDailyChallengeDate,
+      lastCraftedRecipeId,
+    };
+  }
+
+  function closeModal() {
+    setActiveModal(null);
+  }
+
+  async function handleOpenExport() {
+    setMenuOpen(false);
+    setActiveModal("export");
+    setExportValue("");
+    setExportStatus({ message: "압축 문자열을 생성하는 중이에요.", tone: "info" });
+
+    try {
+      const nextValue = await exportGameState(createSnapshot());
+      setExportValue(nextValue);
+      setExportStatus({
+        message: "생성된 문자열을 복사해 다른 환경으로 옮겨 주세요.",
+        tone: "success",
+      });
+    } catch (error) {
+      setExportStatus({
+        message: getErrorMessage(error, "저장 문자열을 생성하지 못했어요."),
+        tone: "error",
+      });
+    }
+  }
+
+  function handleOpenImport() {
+    setMenuOpen(false);
+    setImportValue("");
+    setImportStatus({
+      message: "압축 문자열을 붙여넣은 뒤 가져오기를 눌러 주세요.",
+      tone: "info",
+    });
+    setActiveModal("import");
+  }
+
+  async function handleCopyExport() {
+    const trimmedValue = exportValue.trim();
+    if (!trimmedValue) {
+      setExportStatus({
+        message: "먼저 내보내기 문자열을 생성해 주세요.",
+        tone: "error",
+      });
+      return;
+    }
+
+    try {
+      await navigator.clipboard.writeText(trimmedValue);
+      setExportStatus({ message: "압축 문자열을 클립보드에 복사했어요.", tone: "success" });
+    } catch (error) {
+      console.error("클립보드 복사에 실패했습니다.", error);
+      exportTextareaRef.current?.focus();
+      exportTextareaRef.current?.select();
+
+      if (typeof document.execCommand === "function" && document.execCommand("copy")) {
+        setExportStatus({ message: "압축 문자열을 클립보드에 복사했어요.", tone: "success" });
+        return;
+      }
+
+      setExportStatus({
+        message: "자동 복사에 실패했어요. 문자열을 직접 복사해 주세요.",
+        tone: "error",
+      });
+    }
+  }
+
+  async function handleImport() {
+    setImportStatus({ message: "저장 문자열을 확인하는 중이에요.", tone: "info" });
+
+    try {
+      const importedState = await importGameState(importValue);
+      const confirmed = window.confirm(
+        "현재 브라우저 저장 데이터가 가져온 값으로 전체 교체됩니다. 기존 데이터와 병합되지 않아요. 계속할까요?",
+      );
+
+      if (!confirmed) {
+        setImportStatus({ message: "가져오기를 취소했어요.", tone: "info" });
+        return;
+      }
+
+      startTransition(() => {
+        replaceGameState(importedState);
+      });
+
+      setImportValue("");
+      setActiveModal(null);
+    } catch (error) {
+      setImportStatus({
+        message: getErrorMessage(error, "저장 문자열을 읽지 못했어요."),
+        tone: "error",
+      });
+    }
+  }
+
+  return (
+    <div ref={menuRef} style={menuWrapperStyle}>
+      <button
+        type="button"
+        className="pixel-button pixel-button--ghost"
+        style={triggerStyle}
+        onClick={() => setMenuOpen((current) => !current)}
+        aria-expanded={menuOpen}
+      >
+        저장 관리
+      </button>
+
+      {menuOpen ? (
+        <div style={menuPanelStyle}>
+          <div>
+            <p className="eyebrow">백업 · 이동</p>
+            <strong>압축 문자열로 현재 진행 데이터 옮기기</strong>
+          </div>
+          <p style={menuTextStyle}>
+            내보내기로 현재 브라우저 저장값을 복사하고, 다른 환경에서는 가져오기로 그대로 복원할 수 있어요.
+          </p>
+          <div style={menuActionsStyle}>
+            <button type="button" className="pixel-button pixel-button--primary" onClick={() => void handleOpenExport()}>
+              내보내기
+            </button>
+            <button type="button" className="pixel-button" onClick={handleOpenImport}>
+              가져오기
+            </button>
+          </div>
+        </div>
+      ) : null}
+
+      {activeModal === "export" ? (
+        <div style={overlayStyle} onClick={closeModal}>
+          <div
+            className="panel"
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="save-export-title"
+            style={modalPanelStyle}
+            onClick={(event) => event.stopPropagation()}
+          >
+            <div style={modalHeaderStyle}>
+              <div>
+                <p className="eyebrow">저장 데이터 내보내기</p>
+                <h2 id="save-export-title">압축 문자열 생성</h2>
+              </div>
+              <button type="button" className="mini-button" onClick={closeModal}>
+                닫기
+              </button>
+            </div>
+            <div style={modalBodyStyle}>
+              <p style={menuTextStyle}>
+                아래 문자열을 복사해 두면 다른 브라우저나 기기에서도 현재 진행 상태를 그대로 이어서 플레이할 수 있어요.
+              </p>
+              <textarea
+                ref={exportTextareaRef}
+                value={exportValue}
+                readOnly
+                spellCheck={false}
+                aria-label="내보낸 저장 데이터 문자열"
+                style={textAreaStyle}
+              />
+              <div className="message-box" aria-live="polite" style={getStatusStyle(exportStatus.tone)}>
+                {exportStatus.message}
+              </div>
+              <div style={modalActionsStyle}>
+                <button type="button" className="pixel-button pixel-button--primary" onClick={() => void handleCopyExport()}>
+                  문자열 복사
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+      ) : null}
+
+      {activeModal === "import" ? (
+        <div style={overlayStyle} onClick={closeModal}>
+          <div
+            className="panel"
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="save-import-title"
+            style={modalPanelStyle}
+            onClick={(event) => event.stopPropagation()}
+          >
+            <div style={modalHeaderStyle}>
+              <div>
+                <p className="eyebrow">저장 데이터 가져오기</p>
+                <h2 id="save-import-title">현재 진행 상태 복원</h2>
+              </div>
+              <button type="button" className="mini-button" onClick={closeModal}>
+                닫기
+              </button>
+            </div>
+            <div style={modalBodyStyle}>
+              <p style={menuTextStyle}>
+                내보내기에서 만든 압축 문자열을 붙여넣으면 현재 브라우저 저장 데이터가 가져온 값으로 전체 교체됩니다.
+              </p>
+              <div style={warningStyle}>가져오기를 확정하면 현재 저장 데이터는 덮어쓰이며, 병합되지 않아요.</div>
+              <textarea
+                ref={importTextareaRef}
+                value={importValue}
+                onChange={(event) => setImportValue(event.target.value)}
+                spellCheck={false}
+                aria-label="가져올 저장 데이터 문자열"
+                placeholder="압축된 저장 문자열을 여기에 붙여넣어 주세요."
+                style={textAreaStyle}
+              />
+              <div className="message-box" aria-live="polite" style={getStatusStyle(importStatus.tone)}>
+                {importStatus.message}
+              </div>
+              <div style={modalActionsStyle}>
+                <button type="button" className="pixel-button pixel-button--primary" onClick={() => void handleImport()}>
+                  가져와서 덮어쓰기
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/src/lib/gameState.ts
+++ b/src/lib/gameState.ts
@@ -13,6 +13,29 @@ const STARTER_ITEMS: Array<[string, number]> = [
   ["sparkle-sugar", 1],
 ];
 
+const SAVE_TRANSFER_PREFIX = "daily-cupcake-save";
+const SAVE_TRANSFER_VERSION = 1;
+const REQUIRED_GAME_STATE_KEYS: Array<keyof GameState> = [
+  "inventory",
+  "selection",
+  "discoveredRecipeIds",
+  "collection",
+  "favorites",
+  "pendingBoxes",
+  "lastDeliveryResolvedAt",
+  "lastDailyClaimDate",
+  "dailyStreak",
+  "lastDailyChallengeDate",
+  "lastCraftedRecipeId",
+];
+
+const VALID_SELECTION_VALUES = {
+  batter: new Set(ALL_INGREDIENTS.filter((ingredient) => ingredient.category === "batter").map((ingredient) => ingredient.id)),
+  cream: new Set(ALL_INGREDIENTS.filter((ingredient) => ingredient.category === "cream").map((ingredient) => ingredient.id)),
+  topping: new Set(ALL_INGREDIENTS.filter((ingredient) => ingredient.category === "topping").map((ingredient) => ingredient.id)),
+  finisher: new Set(ALL_INGREDIENTS.filter((ingredient) => ingredient.category === "finisher").map((ingredient) => ingredient.id)),
+} satisfies Record<keyof Selection, Set<string>>;
+
 export const DEFAULT_SELECTION: Selection = {
   batter: null,
   cream: null,
@@ -27,6 +50,70 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 function toFiniteNumber(value: unknown, fallback = 0) {
   const parsed = Number(value);
   return Number.isFinite(parsed) ? parsed : fallback;
+}
+
+function bytesToBase64Url(bytes: Uint8Array) {
+  let binary = "";
+  const chunkSize = 0x8000;
+
+  for (let index = 0; index < bytes.length; index += chunkSize) {
+    const chunk = bytes.subarray(index, index + chunkSize);
+    binary += String.fromCharCode(...chunk);
+  }
+
+  return btoa(binary).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/g, "");
+}
+
+function base64UrlToBytes(value: string) {
+  const normalized = value.replace(/-/g, "+").replace(/_/g, "/");
+  const padding = "=".repeat((4 - (normalized.length % 4 || 4)) % 4);
+  const binary = atob(`${normalized}${padding}`);
+  return Uint8Array.from(binary, (character) => character.charCodeAt(0));
+}
+
+async function gzipText(text: string) {
+  if (typeof CompressionStream === "undefined") {
+    throw new Error("이 브라우저는 저장 문자열 압축을 지원하지 않아요. 최신 브라우저에서 다시 시도해 주세요.");
+  }
+
+  const compressedStream = new Blob([text]).stream().pipeThrough(new CompressionStream("gzip"));
+  return new Uint8Array(await new Response(compressedStream).arrayBuffer());
+}
+
+async function gunzipToText(bytes: Uint8Array) {
+  if (typeof DecompressionStream === "undefined") {
+    throw new Error("이 브라우저는 저장 문자열 복원을 지원하지 않아요. 최신 브라우저에서 다시 시도해 주세요.");
+  }
+
+  const decompressedStream = new Blob([bytes]).stream().pipeThrough(new DecompressionStream("gzip"));
+  return await new Response(decompressedStream).text();
+}
+
+function validateSaveTransferPayload(payload: unknown): asserts payload is {
+  format: string;
+  version: number;
+  data: unknown;
+} {
+  if (!isRecord(payload)) {
+    throw new Error("저장 문자열 안의 데이터 형식이 올바르지 않아요.");
+  }
+
+  if (payload.format !== SAVE_TRANSFER_PREFIX) {
+    throw new Error("이 앱에서 만든 저장 문자열이 아니에요.");
+  }
+
+  if (payload.version !== SAVE_TRANSFER_VERSION) {
+    throw new Error("지원하지 않는 저장 데이터 버전이에요.");
+  }
+
+  if (!isRecord(payload.data)) {
+    throw new Error("가져올 저장 데이터가 비어 있어요.");
+  }
+
+  const missingKeys = REQUIRED_GAME_STATE_KEYS.filter((key) => !(key in payload.data));
+  if (missingKeys.length > 0) {
+    throw new Error("필수 저장 항목이 빠져 있어 가져올 수 없어요.");
+  }
 }
 
 export function clamp(value: number, minimum: number, maximum: number) {
@@ -91,10 +178,22 @@ export function normalizeGameState(rawState: unknown, now = Date.now()): GameSta
 
   const rawSelection = isRecord(rawState.selection) ? rawState.selection : {};
   normalized.selection = {
-    batter: typeof rawSelection.batter === "string" ? rawSelection.batter : null,
-    cream: typeof rawSelection.cream === "string" ? rawSelection.cream : null,
-    topping: typeof rawSelection.topping === "string" ? rawSelection.topping : null,
-    finisher: typeof rawSelection.finisher === "string" ? rawSelection.finisher : null,
+    batter:
+      typeof rawSelection.batter === "string" && VALID_SELECTION_VALUES.batter.has(rawSelection.batter)
+        ? rawSelection.batter
+        : null,
+    cream:
+      typeof rawSelection.cream === "string" && VALID_SELECTION_VALUES.cream.has(rawSelection.cream)
+        ? rawSelection.cream
+        : null,
+    topping:
+      typeof rawSelection.topping === "string" && VALID_SELECTION_VALUES.topping.has(rawSelection.topping)
+        ? rawSelection.topping
+        : null,
+    finisher:
+      typeof rawSelection.finisher === "string" && VALID_SELECTION_VALUES.finisher.has(rawSelection.finisher)
+        ? rawSelection.finisher
+        : null,
   };
 
   const validRecipeIds = new Set(RECIPES.map((recipe) => recipe.id));
@@ -176,4 +275,52 @@ export function clearPersistedGameState() {
   }
 
   window.localStorage.removeItem(STORAGE_KEY);
+}
+
+export async function exportGameState(snapshot: GameState) {
+  const payload = JSON.stringify({
+    format: SAVE_TRANSFER_PREFIX,
+    version: SAVE_TRANSFER_VERSION,
+    storageKey: STORAGE_KEY,
+    exportedAt: new Date().toISOString(),
+    data: cloneGameState(snapshot),
+  });
+
+  const compressed = await gzipText(payload);
+  return `${SAVE_TRANSFER_PREFIX}:${SAVE_TRANSFER_VERSION}:${bytesToBase64Url(compressed)}`;
+}
+
+export async function importGameState(rawValue: string, now = Date.now()) {
+  const trimmedValue = rawValue.trim();
+  if (!trimmedValue) {
+    throw new Error("가져올 문자열을 먼저 붙여넣어 주세요.");
+  }
+
+  const [format, version, encoded, ...rest] = trimmedValue.split(":");
+  if (!format || !version || !encoded || rest.length > 0) {
+    throw new Error("저장 문자열 형식이 올바르지 않아요.");
+  }
+
+  if (format !== SAVE_TRANSFER_PREFIX || version !== String(SAVE_TRANSFER_VERSION)) {
+    throw new Error("지원하지 않는 저장 문자열이에요.");
+  }
+
+  let decodedText = "";
+  try {
+    decodedText = await gunzipToText(base64UrlToBytes(encoded));
+  } catch (error) {
+    console.error("저장 문자열을 해제하지 못했습니다.", error);
+    throw new Error("문자열을 풀지 못했어요. 손상되었거나 잘못된 데이터예요.");
+  }
+
+  let payload: unknown;
+  try {
+    payload = JSON.parse(decodedText);
+  } catch (error) {
+    console.error("저장 문자열의 JSON 파싱에 실패했습니다.", error);
+    throw new Error("저장 문자열 안의 데이터 형식이 올바르지 않아요.");
+  }
+
+  validateSaveTransferPayload(payload);
+  return normalizeGameState(payload.data, now);
 }

--- a/src/store/gameStore.ts
+++ b/src/store/gameStore.ts
@@ -14,6 +14,7 @@ import {
 } from "../lib/gameLogic";
 import {
   clearPersistedGameState,
+  cloneGameState,
   createInitialGameState,
   DEFAULT_SELECTION,
   loadPersistedGameState,
@@ -30,6 +31,7 @@ const DEFAULT_UI_STATE: UiState = {
 export interface GameStore extends GameState, UiState {
   activePage: PageId;
   setActivePage: (page: PageId) => void;
+  replaceGameState: (nextState: GameState) => void;
   syncDeliveryBoxes: (now?: number) => void;
   claimPendingBoxes: () => void;
   claimDailyGift: () => void;
@@ -63,6 +65,17 @@ export const useGameStore = create<GameStore>((set, get) => ({
 
   setActivePage: (activePage) => {
     set({ activePage });
+  },
+
+  replaceGameState: (nextState) => {
+    const snapshot = cloneGameState(nextState);
+    set((state) => ({
+      ...snapshot,
+      activePage: state.activePage,
+      deliveryMessage: "저장 데이터를 가져와 현재 진행 상태를 복원했어요.",
+      craftMessage: "",
+      challengeMessage: "",
+    }));
   },
 
   syncDeliveryBoxes: (now = Date.now()) => {


### PR DESCRIPTION
## Summary
- add a header-right save management dropdown for exporting and importing saves
- serialize the full persisted game state into a compressed single-string payload
- restore imported saves into the current session without a reload

## Testing
- not run locally in the current automation workspace

Closes #4