### PR TITLE
[codex] Fix runtime render loop and deploy failures

### DIFF
--- a/src/lib/gameState.test.ts
+++ b/src/lib/gameState.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+import { RECIPES } from "../data/gameData";
+import { createInitialGameState, exportGameState, importGameState, normalizeGameState } from "./gameState";
+
+describe("save transfer", () => {
+  it("round-trips an exported save", async () => {
+    const recipeId = RECIPES[0].id;
+    const state = createInitialGameState(123);
+
+    state.pendingBoxes = 1;
+    state.lastDeliveryResolvedAt = 456;
+    state.lastDailyClaimDate = "2026-04-07";
+    state.dailyStreak = 3;
+    state.lastDailyChallengeDate = "2026-04-06";
+    state.lastCraftedRecipeId = recipeId;
+    state.discoveredRecipeIds = [recipeId];
+    state.favorites = [recipeId];
+    state.collection[recipeId] = {
+      count: 2,
+      firstCraftedAt: 111,
+      lastCraftedAt: 222,
+    };
+
+    const exported = await exportGameState(state);
+    const imported = await importGameState(exported, 999);
+
+    expect(imported).toEqual(normalizeGameState(state, 999));
+  });
+
+  it("rejects malformed transfer strings", async () => {
+    await expect(importGameState("daily-cupcake-save:1:not-valid")).rejects.toThrow();
+  });
+});

--- a/src/lib/gameState.ts
+++ b/src/lib/gameState.ts
@@ -43,6 +43,12 @@ export const DEFAULT_SELECTION: Selection = {
   finisher: null,
 };
 
+type SaveTransferPayload = {
+  format: string;
+  version: number;
+  data: Record<string, unknown>;
+};
+
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null;
 }
@@ -85,15 +91,13 @@ async function gunzipToText(bytes: Uint8Array) {
     throw new Error("이 브라우저는 저장 문자열 복원을 지원하지 않아요. 최신 브라우저에서 다시 시도해 주세요.");
   }
 
-  const decompressedStream = new Blob([bytes]).stream().pipeThrough(new DecompressionStream("gzip"));
+  const decompressedStream = new Blob([Uint8Array.from(bytes)])
+    .stream()
+    .pipeThrough(new DecompressionStream("gzip"));
   return await new Response(decompressedStream).text();
 }
 
-function validateSaveTransferPayload(payload: unknown): asserts payload is {
-  format: string;
-  version: number;
-  data: unknown;
-} {
+function validateSaveTransferPayload(payload: unknown): asserts payload is SaveTransferPayload {
   if (!isRecord(payload)) {
     throw new Error("저장 문자열 안의 데이터 형식이 올바르지 않아요.");
   }
@@ -106,11 +110,12 @@ function validateSaveTransferPayload(payload: unknown): asserts payload is {
     throw new Error("지원하지 않는 저장 데이터 버전이에요.");
   }
 
-  if (!isRecord(payload.data)) {
+  const data = payload.data;
+  if (!isRecord(data)) {
     throw new Error("가져올 저장 데이터가 비어 있어요.");
   }
 
-  const missingKeys = REQUIRED_GAME_STATE_KEYS.filter((key) => !(key in payload.data));
+  const missingKeys = REQUIRED_GAME_STATE_KEYS.filter((key) => !(key in data));
   if (missingKeys.length > 0) {
     throw new Error("필수 저장 항목이 빠져 있어 가져올 수 없어요.");
   }

--- a/src/pages/BakeryPage.tsx
+++ b/src/pages/BakeryPage.tsx
@@ -1,5 +1,6 @@
 import type { CSSProperties } from "react";
 import ovenStage from "../../assets/images/oven-stage.png";
+import { useShallow } from "zustand/react/shallow";
 import { CupcakeArt } from "../components/CupcakeArt";
 import { Tag } from "../components/Tag";
 import { CATEGORY_META, INGREDIENT_GROUPS, INGREDIENT_MAP, RECIPES, getRecipeFromSelection } from "../data/gameData";
@@ -24,19 +25,21 @@ export function BakeryPage() {
     clearSelection,
     craftCupcake,
     toggleFavorite,
-  } = useGameStore((state) => ({
-    inventory: state.inventory,
-    selection: state.selection,
-    discoveredRecipeIds: state.discoveredRecipeIds,
-    collection: state.collection,
-    favorites: state.favorites,
-    craftMessage: state.craftMessage,
-    lastCraftedRecipeId: state.lastCraftedRecipeId,
-    toggleSelection: state.toggleSelection,
-    clearSelection: state.clearSelection,
-    craftCupcake: state.craftCupcake,
-    toggleFavorite: state.toggleFavorite,
-  }));
+  } = useGameStore(
+    useShallow((state) => ({
+      inventory: state.inventory,
+      selection: state.selection,
+      discoveredRecipeIds: state.discoveredRecipeIds,
+      collection: state.collection,
+      favorites: state.favorites,
+      craftMessage: state.craftMessage,
+      lastCraftedRecipeId: state.lastCraftedRecipeId,
+      toggleSelection: state.toggleSelection,
+      clearSelection: state.clearSelection,
+      craftCupcake: state.craftCupcake,
+      toggleFavorite: state.toggleFavorite,
+    })),
+  );
 
   const spotlightIngredients = getTopInventoryIngredients(inventory);
   const selectedRecipe = getRecipeFromSelection(selection);

--- a/src/pages/CollectionPage.tsx
+++ b/src/pages/CollectionPage.tsx
@@ -1,4 +1,5 @@
 import { useDeferredValue, useState } from "react";
+import { useShallow } from "zustand/react/shallow";
 import { CupcakeArt } from "../components/CupcakeArt";
 import { Tag } from "../components/Tag";
 import { COLLECTION_META, RARITY_META, RECIPE_MAP, RECIPES } from "../data/gameData";
@@ -6,10 +7,12 @@ import { getDiscoveryProgressPercent } from "../lib/gameLogic";
 import { useGameStore } from "../store/gameStore";
 
 export function CollectionPage() {
-  const { discoveredRecipeIds, collection } = useGameStore((state) => ({
-    discoveredRecipeIds: state.discoveredRecipeIds,
-    collection: state.collection,
-  }));
+  const { discoveredRecipeIds, collection } = useGameStore(
+    useShallow((state) => ({
+      discoveredRecipeIds: state.discoveredRecipeIds,
+      collection: state.collection,
+    })),
+  );
 
   const [rarityFilter, setRarityFilter] = useState("all");
   const [collectionFilter, setCollectionFilter] = useState("all");

--- a/src/pages/DeliveryPage.tsx
+++ b/src/pages/DeliveryPage.tsx
@@ -1,4 +1,5 @@
 import { CupcakeArt } from "../components/CupcakeArt";
+import { useShallow } from "zustand/react/shallow";
 import { Tag } from "../components/Tag";
 import { MAX_PENDING_BOXES } from "../config/game";
 import { getDailyRecipe } from "../data/gameData";
@@ -18,15 +19,17 @@ export function DeliveryPage({ now }: DeliveryPageProps) {
     lastDailyChallengeDate,
     claimPendingBoxes,
     claimDailyGift,
-  } = useGameStore((state) => ({
-    pendingBoxes: state.pendingBoxes,
-    deliveryMessage: state.deliveryMessage,
-    challengeMessage: state.challengeMessage,
-    lastDailyClaimDate: state.lastDailyClaimDate,
-    lastDailyChallengeDate: state.lastDailyChallengeDate,
-    claimPendingBoxes: state.claimPendingBoxes,
-    claimDailyGift: state.claimDailyGift,
-  }));
+  } = useGameStore(
+    useShallow((state) => ({
+      pendingBoxes: state.pendingBoxes,
+      deliveryMessage: state.deliveryMessage,
+      challengeMessage: state.challengeMessage,
+      lastDailyClaimDate: state.lastDailyClaimDate,
+      lastDailyChallengeDate: state.lastDailyChallengeDate,
+      claimPendingBoxes: state.claimPendingBoxes,
+      claimDailyGift: state.claimDailyGift,
+    })),
+  );
 
   const todayKey = getTodayKey(now);
   const dailyRecipe = getDailyRecipe(todayKey);

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -1,4 +1,5 @@
 import heroBakery from "../../assets/images/hero-bakery.png";
+import { useShallow } from "zustand/react/shallow";
 import { MAX_PENDING_BOXES, SHOWCASE_LIMIT } from "../config/game";
 import { RECIPES } from "../data/gameData";
 import {
@@ -32,22 +33,24 @@ export function HomePage({ now, onNavigate }: HomePageProps) {
     challengeMessage,
     claimDailyGift,
     resetGame,
-  } = useGameStore((state) => ({
-    inventory: state.inventory,
-    collection: state.collection,
-    discoveredRecipeIds: state.discoveredRecipeIds,
-    favorites: state.favorites,
-    pendingBoxes: state.pendingBoxes,
-    dailyStreak: state.dailyStreak,
-    lastDailyClaimDate: state.lastDailyClaimDate,
-    lastDailyChallengeDate: state.lastDailyChallengeDate,
-    lastDeliveryResolvedAt: state.lastDeliveryResolvedAt,
-    deliveryMessage: state.deliveryMessage,
-    craftMessage: state.craftMessage,
-    challengeMessage: state.challengeMessage,
-    claimDailyGift: state.claimDailyGift,
-    resetGame: state.resetGame,
-  }));
+  } = useGameStore(
+    useShallow((state) => ({
+      inventory: state.inventory,
+      collection: state.collection,
+      discoveredRecipeIds: state.discoveredRecipeIds,
+      favorites: state.favorites,
+      pendingBoxes: state.pendingBoxes,
+      dailyStreak: state.dailyStreak,
+      lastDailyClaimDate: state.lastDailyClaimDate,
+      lastDailyChallengeDate: state.lastDailyChallengeDate,
+      lastDeliveryResolvedAt: state.lastDeliveryResolvedAt,
+      deliveryMessage: state.deliveryMessage,
+      craftMessage: state.craftMessage,
+      challengeMessage: state.challengeMessage,
+      claimDailyGift: state.claimDailyGift,
+      resetGame: state.resetGame,
+    })),
+  );
 
   const discoveredCount = discoveredRecipeIds.length;
   const progressPercent = getDiscoveryProgressPercent(discoveredCount, RECIPES.length);

--- a/src/pages/ShowcasePage.tsx
+++ b/src/pages/ShowcasePage.tsx
@@ -1,15 +1,18 @@
 import showcaseShelf from "../../assets/images/showcase-shelf.png";
+import { useShallow } from "zustand/react/shallow";
 import { CupcakeArt } from "../components/CupcakeArt";
 import { Tag } from "../components/Tag";
 import { RECIPE_MAP } from "../data/gameData";
 import { useGameStore } from "../store/gameStore";
 
 export function ShowcasePage() {
-  const { favorites, collection, toggleFavorite } = useGameStore((state) => ({
-    favorites: state.favorites,
-    collection: state.collection,
-    toggleFavorite: state.toggleFavorite,
-  }));
+  const { favorites, collection, toggleFavorite } = useGameStore(
+    useShallow((state) => ({
+      favorites: state.favorites,
+      collection: state.collection,
+      toggleFavorite: state.toggleFavorite,
+    })),
+  );
 
   const favoriteRecipes = favorites
     .map((recipeId) => RECIPE_MAP.get(recipeId))


### PR DESCRIPTION
## What changed
- fix the save transfer TypeScript issues that blocked the Pages build
- stabilize Zustand selectors in page components with `useShallow` to stop the React render loop in production
- add a save transfer round-trip test to cover export/import behavior

## Root cause
- the deploy workflow was failing because `src/lib/gameState.ts` no longer type-checked under the current TypeScript DOM typings
- the runtime blank screen came from object-returning Zustand selectors in page components, which triggered an update loop with the current React/Zustand combination

## Validation
- `npm run test`
- `npm run build`
- static build rendered successfully in a headless browser against the built `dist`
