### PR TITLE
[codex] support freeform ingredient mixing and upgrades

### DIFF
--- a/src/components/CupcakeArt.tsx
+++ b/src/components/CupcakeArt.tsx
@@ -20,19 +20,25 @@ export function CupcakeArt({ recipe, size = "medium" }: CupcakeArtProps) {
     "--collection-color": recipe.palette.collection,
   } as CSSProperties;
 
-  const toppingLabel = recipe.ingredients[2]?.short ?? "";
-  const finishLabel = recipe.ingredients[3]?.short ?? "";
+  const toppingIngredient =
+    recipe.ingredients.find((ingredient) => ingredient.category === "topping") ??
+    recipe.ingredients.at(-1) ??
+    recipe.ingredients[0];
+  const finishIngredient =
+    recipe.ingredients.find((ingredient) => ingredient.category === "finisher") ??
+    recipe.ingredients.at(0) ??
+    recipe.ingredients.at(-1);
 
   return (
     <div className={`cupcake-art cupcake-art--${size}`} style={style}>
       <div className="cupcake-art__sparkle" />
-      <div className="cupcake-art__finish">{finishLabel}</div>
+      <div className="cupcake-art__finish">{finishIngredient?.short ?? ""}</div>
       <div className="cupcake-art__cream">
         <span />
         <span />
         <span />
       </div>
-      <div className="cupcake-art__topping">{toppingLabel}</div>
+      <div className="cupcake-art__topping">{toppingIngredient?.short ?? ""}</div>
       <div className="cupcake-art__cake" />
       <div className="cupcake-art__wrapper" />
     </div>

--- a/src/components/SaveTransferMenu.tsx
+++ b/src/components/SaveTransferMenu.tsx
@@ -163,6 +163,7 @@ export function SaveTransferMenu() {
     dailyStreak,
     lastDailyChallengeDate,
     lastCraftedRecipeId,
+    lastMixResult,
     replaceGameState,
   } = useGameStore(
     useShallow((state) => ({
@@ -177,6 +178,7 @@ export function SaveTransferMenu() {
       dailyStreak: state.dailyStreak,
       lastDailyChallengeDate: state.lastDailyChallengeDate,
       lastCraftedRecipeId: state.lastCraftedRecipeId,
+      lastMixResult: state.lastMixResult,
       replaceGameState: state.replaceGameState,
     })),
   );
@@ -268,6 +270,7 @@ export function SaveTransferMenu() {
       dailyStreak,
       lastDailyChallengeDate,
       lastCraftedRecipeId,
+      lastMixResult,
     };
   }
 
@@ -417,7 +420,8 @@ export function SaveTransferMenu() {
             </div>
             <div style={modalBodyStyle}>
               <p style={menuTextStyle}>
-                아래 문자열을 복사해 두면 다른 브라우저나 기기에서도 현재 진행 상태를 그대로 이어서 플레이할 수 있어요.
+                아래 문자열을 복사해 두면 다른 브라우저나 기기에서도 현재 진행 상태를 그대로 이어서 플레이할 수
+                있어요.
               </p>
               <textarea
                 ref={exportTextareaRef}

--- a/src/data/gameData.test.ts
+++ b/src/data/gameData.test.ts
@@ -1,32 +1,31 @@
 import { describe, expect, it } from "vitest";
 import {
   FALLBACK_INGREDIENT_POOLS,
-  FREEFORM_CUPCAKE_RECIPES,
   INGREDIENT_MAP,
   INGREDIENT_UPGRADE_RECIPES,
+  RECIPES,
   getFallbackIngredientPool,
   getFreeformCupcakeRecipe,
+  getHighestIngredientRank,
   getIngredientUpgradeRecipe,
 } from "./gameData";
 
 describe("freeform mixing data", () => {
   it("defines cupcake recipes with 2 to 5 ingredients", () => {
-    expect(FREEFORM_CUPCAKE_RECIPES.length).toBeGreaterThan(0);
+    expect(RECIPES.length).toBeGreaterThan(0);
+    expect(RECIPES.every((recipe) => recipe.ingredientIds.length >= 2 && recipe.ingredientIds.length <= 5)).toBe(
+      true,
+    );
+    expect(RECIPES.some((recipe) => recipe.ingredientIds.length === 2)).toBe(true);
     expect(
-      FREEFORM_CUPCAKE_RECIPES.every(
-        (recipe) => recipe.ingredientIds.length >= 2 && recipe.ingredientIds.length <= 5,
-      ),
-    ).toBe(true);
-    expect(FREEFORM_CUPCAKE_RECIPES.some((recipe) => recipe.ingredientIds.length === 2)).toBe(true);
-    expect(
-      FREEFORM_CUPCAKE_RECIPES.some(
+      RECIPES.some(
         (recipe) => new Set(recipe.ingredients.map((ingredient) => ingredient.category)).size < recipe.ingredients.length,
       ),
     ).toBe(true);
   });
 
   it("matches cupcake recipes regardless of ingredient order", () => {
-    const recipe = FREEFORM_CUPCAKE_RECIPES.find((entry) => entry.id === "dream-parade-float");
+    const recipe = RECIPES.find((entry) => entry.id === "dream-parade-float");
     expect(recipe).toBeDefined();
     expect(getFreeformCupcakeRecipe([...recipe!.ingredientIds].reverse())?.id).toBe(recipe!.id);
   });
@@ -49,5 +48,10 @@ describe("freeform mixing data", () => {
       );
       expect(getFallbackIngredientPool(pool.rank)?.ingredientIds).toEqual(pool.ingredientIds);
     }
+  });
+
+  it("uses the highest mixed ingredient rank for fallback buckets", () => {
+    expect(getHighestIngredientRank(["vanilla-cloud", "milk-cloud"])).toBe("base");
+    expect(getHighestIngredientRank(["vanilla-cloud", "matcha-forest"])).toBe("refined");
   });
 });

--- a/src/data/gameData.ts
+++ b/src/data/gameData.ts
@@ -8,7 +8,6 @@ import type {
   IngredientRank,
   IngredientRankMetaEntry,
   IngredientUpgradeRecipe,
-  MixingCupcakeRecipe,
   Rarity,
   RarityMetaEntry,
   Recipe,
@@ -283,7 +282,7 @@ const FINISHERS: Ingredient[] = [
 ];
 
 const CATEGORY_META: CategoryMeta[] = [
-  { id: "batter", label: "반죽", description: "컵케이크의 바닥이 되는 폭신한 반죽" },
+  { id: "batter", label: "반죽", description: "컵케이크 바닥이 되는 포근한 반죽" },
   { id: "cream", label: "크림", description: "위에 올리는 메인 크림" },
   { id: "topping", label: "토핑", description: "귀여운 장식과 포인트 토핑" },
   { id: "finisher", label: "마무리", description: "마지막 분위기를 결정하는 장식" },
@@ -345,27 +344,6 @@ function pickDominantFamily(ingredients: Ingredient[]): IngredientFamily {
   })[0]?.[0] ?? "cloud";
 }
 
-function computeLegacyRarityScore(parts: Ingredient[]) {
-  const baseScore = parts.reduce((sum, item) => sum + item.rarity, 0);
-  let synergy = 0;
-
-  if (parts[0]?.family === parts[1]?.family) {
-    synergy += 2;
-  }
-  if (parts[2]?.family === parts[3]?.family) {
-    synergy += 2;
-  }
-
-  const familyCount = parts.reduce<Map<IngredientFamily, number>>((accumulator, item) => {
-    accumulator.set(item.family, (accumulator.get(item.family) ?? 0) + 1);
-    return accumulator;
-  }, new Map<IngredientFamily, number>());
-
-  const dominantCount = Math.max(...familyCount.values(), 1);
-  synergy += dominantCount - 1;
-  return baseScore + synergy;
-}
-
 function computeMixingRarityScore(ingredients: Ingredient[]) {
   const baseScore = ingredients.reduce((sum, ingredient) => sum + ingredient.rarity, 0);
   const familyCount = ingredients.reduce<Map<IngredientFamily, number>>((accumulator, ingredient) => {
@@ -389,25 +367,6 @@ function classifyRarity(score: number): Rarity {
     return "rare";
   }
   return "common";
-}
-
-function buildLegacyRecipeDescription(
-  batter: Ingredient,
-  cream: Ingredient,
-  topping: Ingredient,
-  finisher: Ingredient,
-  collectionLabel: string,
-) {
-  return `${batter.name} 위에 ${cream.name}을 풍성하게 올리고 ${topping.name}와 ${finisher.name}로 마무리한 ${collectionLabel} 시그니처 컵케이크.`;
-}
-
-function buildLegacyRecipeTitle(
-  batter: Ingredient,
-  cream: Ingredient,
-  topping: Ingredient,
-  finisher: Ingredient,
-) {
-  return `${finisher.short} ${cream.short} ${batter.short} ${topping.short} 컵케이크`;
 }
 
 function buildPaletteFromIngredients(
@@ -436,54 +395,6 @@ function buildPaletteFromIngredients(
   };
 }
 
-function buildRecipes() {
-  const recipes: Recipe[] = [];
-  let index = 0;
-
-  BATTERS.forEach((batter) => {
-    CREAMS.forEach((cream) => {
-      TOPPINGS.forEach((topping) => {
-        FINISHERS.forEach((finisher) => {
-          const parts = [batter, cream, topping, finisher];
-          const dominantFamily = pickDominantFamily(parts);
-          const collection = COLLECTION_META[dominantFamily];
-          const rarityScore = computeLegacyRarityScore(parts);
-          const rarity = classifyRarity(rarityScore);
-
-          recipes.push({
-            id: `${batter.id}__${cream.id}__${topping.id}__${finisher.id}`,
-            index,
-            name: buildLegacyRecipeTitle(batter, cream, topping, finisher),
-            description: buildLegacyRecipeDescription(
-              batter,
-              cream,
-              topping,
-              finisher,
-              collection.label,
-            ),
-            collection: dominantFamily,
-            collectionLabel: collection.label,
-            rarity,
-            rarityLabel: RARITY_META[rarity].label,
-            ingredientIds: {
-              batter: batter.id,
-              cream: cream.id,
-              topping: topping.id,
-              finisher: finisher.id,
-            },
-            ingredients: parts,
-            palette: buildPaletteFromIngredients(parts, rarity, dominantFamily),
-          });
-
-          index += 1;
-        });
-      });
-    });
-  });
-
-  return recipes;
-}
-
 function resolveIngredients(ingredientIds: string[]) {
   return ingredientIds.map((ingredientId) => {
     const ingredient = INGREDIENT_MAP.get(ingredientId);
@@ -498,7 +409,7 @@ function createMixingKey(ingredientIds: string[]) {
   return [...ingredientIds].sort((left, right) => left.localeCompare(right, "en")).join("::");
 }
 
-function buildMixingCupcakeRecipe(spec: FreeformCupcakeRecipeSpec): MixingCupcakeRecipe {
+function buildRecipe(spec: FreeformCupcakeRecipeSpec): Recipe {
   const ingredients = resolveIngredients(spec.ingredientIds);
   const collection = pickDominantFamily(ingredients);
   const rarity = classifyRarity(computeMixingRarityScore(ingredients));
@@ -538,14 +449,14 @@ function buildIngredientUpgradeRecipe(spec: IngredientUpgradeRecipeSpec): Ingred
 const FREEFORM_CUPCAKE_RECIPE_SPECS: FreeformCupcakeRecipeSpec[] = [
   {
     id: "cloud-blanket-shortcake",
-    name: "구름 담요 숏케이크",
-    description: "바닐라 구름 반죽과 우유 구름 크림만으로 폭신함을 끝까지 밀어붙인 가장 단순한 자유 조합 컵케이크.",
+    name: "구름 담요 쇼트케이크",
+    description: "바닐라 구름 반죽과 우유 구름 크림만으로 포근함을 끝까지 밀어붙인 가장 단순한 자유 조합 컵케이크.",
     ingredientIds: ["vanilla-cloud", "milk-cloud"],
   },
   {
     id: "berry-ribbon-party",
     name: "베리 리본 파티 컵케이크",
-    description: "딸기 계열 재료를 정석졁으로 쌓아 올린 기본형 축제 조합.",
+    description: "딸기 계열 재료를 정석적으로 쌓아 올린 기본형 축제 조합.",
     ingredientIds: ["strawberry-fairy", "strawberry-butter", "cherry-bloom", "pink-ribbon"],
   },
   {
@@ -587,7 +498,7 @@ const FREEFORM_CUPCAKE_RECIPE_SPECS: FreeformCupcakeRecipeSpec[] = [
   {
     id: "garden-ribbon-sonata",
     name: "가든 리본 소나타 컵케이크",
-    description: "크림치즈와 꽃잎, 체리, 리본을 묶어 정원 계열 디저트를 완성하는 안정졁인 4재료 조합.",
+    description: "크림치즈와 꽃잎, 체리, 리본을 묶어 정원 계열 디저트를 완성하는 안정적인 4재료 조합.",
     ingredientIds: ["cream-cheese", "flower-candy", "pink-ribbon", "cherry-bloom"],
   },
 ];
@@ -631,15 +542,8 @@ const INGREDIENT_UPGRADE_RECIPE_SPECS: IngredientUpgradeRecipeSpec[] = [
   },
 ];
 
-const RECIPES: Recipe[] = buildRecipes();
+const RECIPES: Recipe[] = FREEFORM_CUPCAKE_RECIPE_SPECS.map((spec) => buildRecipe(spec));
 const RECIPE_MAP: Map<string, Recipe> = new Map(RECIPES.map((recipe) => [recipe.id, recipe]));
-
-const FREEFORM_CUPCAKE_RECIPES: MixingCupcakeRecipe[] = FREEFORM_CUPCAKE_RECIPE_SPECS.map((spec) =>
-  buildMixingCupcakeRecipe(spec),
-);
-const FREEFORM_CUPCAKE_RECIPE_MAP = new Map(
-  FREEFORM_CUPCAKE_RECIPES.map((recipe) => [createMixingKey(recipe.ingredientIds), recipe]),
-);
 
 const INGREDIENT_UPGRADE_RECIPES: IngredientUpgradeRecipe[] = INGREDIENT_UPGRADE_RECIPE_SPECS.map((spec) =>
   buildIngredientUpgradeRecipe(spec),
@@ -668,21 +572,16 @@ const FALLBACK_INGREDIENT_POOL_MAP = new Map(
   FALLBACK_INGREDIENT_POOLS.map((pool) => [pool.rank, pool]),
 );
 
-function getRecipeIdFromSelection(selection: Selection) {
-  if (!selection.batter || !selection.cream || !selection.topping || !selection.finisher) {
+function getRecipeFromSelection(selection: Selection): Recipe | null {
+  if (selection.length < 2 || selection.length > 5) {
     return null;
   }
 
-  return `${selection.batter}__${selection.cream}__${selection.topping}__${selection.finisher}`;
-}
-
-function getRecipeFromSelection(selection: Selection): Recipe | null {
-  const recipeId = getRecipeIdFromSelection(selection);
-  return recipeId ? RECIPE_MAP.get(recipeId) ?? null : null;
+  return RECIPE_MAP.get(createMixingKey(selection)) ?? null;
 }
 
 function getFreeformCupcakeRecipe(ingredientIds: string[]) {
-  return FREEFORM_CUPCAKE_RECIPE_MAP.get(createMixingKey(ingredientIds)) ?? null;
+  return RECIPE_MAP.get(createMixingKey(ingredientIds)) ?? null;
 }
 
 function getIngredientUpgradeRecipe(ingredientIds: string[]) {
@@ -691,6 +590,11 @@ function getIngredientUpgradeRecipe(ingredientIds: string[]) {
 
 function getFallbackIngredientPool(rank: IngredientRank) {
   return FALLBACK_INGREDIENT_POOL_MAP.get(rank) ?? null;
+}
+
+function getHighestIngredientRank(ingredientIds: string[]): IngredientRank {
+  const ingredients = resolveIngredients(ingredientIds);
+  return ingredients.some((ingredient) => ingredient.rank === "refined") ? "refined" : "base";
 }
 
 function hashString(value: string) {
@@ -712,7 +616,6 @@ export {
   CREAMS,
   FALLBACK_INGREDIENT_POOLS,
   FINISHERS,
-  FREEFORM_CUPCAKE_RECIPES,
   INGREDIENT_GROUPS,
   INGREDIENT_MAP,
   INGREDIENT_RANK_META,
@@ -725,7 +628,7 @@ export {
   getDailyRecipe,
   getFallbackIngredientPool,
   getFreeformCupcakeRecipe,
+  getHighestIngredientRank,
   getIngredientUpgradeRecipe,
   getRecipeFromSelection,
-  getRecipeIdFromSelection,
 };

--- a/src/lib/gameLogic.test.ts
+++ b/src/lib/gameLogic.test.ts
@@ -1,7 +1,7 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { DELIVERY_MS, MAX_PENDING_BOXES } from "../config/game";
 import { RECIPES, getDailyRecipe, getRecipeFromSelection } from "../data/gameData";
-import { getCraftedRecipePreview, synchronizePendingBoxes } from "./gameLogic";
+import { getCraftPreview, getCraftedRecipePreview, resolveCraftResult, synchronizePendingBoxes } from "./gameLogic";
 import { createInitialGameState, normalizeGameState } from "./gameState";
 
 describe("game bootstrap", () => {
@@ -29,53 +29,52 @@ describe("game bootstrap", () => {
   });
 });
 
-describe("recipes", () => {
-  it("resolves a recipe from the selected ingredients", () => {
-    const recipe = getRecipeFromSelection({
-      batter: "vanilla-cloud",
-      cream: "milk-cloud",
-      topping: "cherry-bloom",
-      finisher: "pink-ribbon",
-    });
+describe("freeform crafting", () => {
+  it("resolves a freeform cupcake recipe regardless of ingredient order", () => {
+    const recipe = getRecipeFromSelection(["pink-ribbon", "strawberry-butter", "cherry-bloom", "strawberry-fairy"]);
 
-    expect(recipe?.id).toBe("vanilla-cloud__milk-cloud__cherry-bloom__pink-ribbon");
-  });
-
-  it("picks the same daily recipe for the same day", () => {
-    expect(getDailyRecipe("2026-04-07").id).toBe(getDailyRecipe("2026-04-07").id);
+    expect(recipe?.id).toBe("berry-ribbon-party");
   });
 
   it("returns a preview for an exact crafted combination", () => {
-    const selection = {
-      batter: "vanilla-cloud",
-      cream: "milk-cloud",
-      topping: "cherry-bloom",
-      finisher: "pink-ribbon",
-    } as const;
-    const preview = getCraftedRecipePreview(selection, {
-      "vanilla-cloud__milk-cloud__cherry-bloom__pink-ribbon": {
+    const preview = getCraftedRecipePreview(["milk-cloud", "vanilla-cloud"], {
+      "cloud-blanket-shortcake": {
         count: 3,
         firstCraftedAt: 100,
         lastCraftedAt: 200,
       },
     });
 
-    expect(preview?.recipe.id).toBe("vanilla-cloud__milk-cloud__cherry-bloom__pink-ribbon");
+    expect(preview?.recipe.id).toBe("cloud-blanket-shortcake");
     expect(preview?.record.count).toBe(3);
   });
 
-  it("does not return a preview for an uncrafted combination", () => {
-    const preview = getCraftedRecipePreview(
-      {
-        batter: "vanilla-cloud",
-        cream: "milk-cloud",
-        topping: "cherry-bloom",
-        finisher: "pink-ribbon",
-      },
-      {},
-    );
+  it("shows an upgrade preview when the selection matches a rank-up recipe", () => {
+    const preview = getCraftPreview(["sparkle-sugar", "milk-cloud", "vanilla-cloud"], {});
 
-    expect(preview).toBeNull();
+    expect(preview.kind).toBe("upgrade");
+    if (preview.kind === "upgrade") {
+      expect(preview.ingredient.id).toBe("bunny-marshmallow");
+    }
+  });
+
+  it("returns a refined fallback ingredient when refined ingredients are mixed without a recipe", () => {
+    const randomSpy = vi.spyOn(Math, "random").mockReturnValue(0);
+
+    try {
+      const result = resolveCraftResult(["matcha-forest", "heart-sprinkle"]);
+      expect(result?.type).toBe("ingredient");
+      if (result?.type === "ingredient") {
+        expect(result.rank).toBe("refined");
+        expect(result.ingredient.rank).toBe("refined");
+      }
+    } finally {
+      randomSpy.mockRestore();
+    }
+  });
+
+  it("picks the same daily recipe for the same day", () => {
+    expect(getDailyRecipe("2026-04-07").id).toBe(getDailyRecipe("2026-04-07").id);
   });
 });
 

--- a/src/lib/gameLogic.ts
+++ b/src/lib/gameLogic.ts
@@ -1,7 +1,55 @@
 import { DAILY_TIMEZONE, DELIVERY_MS, MAX_PENDING_BOXES } from "../config/game";
-import { ALL_INGREDIENTS, CATEGORY_META, INGREDIENT_GROUPS, INGREDIENT_MAP, getRecipeFromSelection } from "../data/gameData";
-import type { CategoryId, GameState, Inventory, Selection } from "../types/game";
+import {
+  ALL_INGREDIENTS,
+  CATEGORY_META,
+  INGREDIENT_GROUPS,
+  INGREDIENT_MAP,
+  INGREDIENT_RANK_META,
+  getFallbackIngredientPool,
+  getFreeformCupcakeRecipe,
+  getHighestIngredientRank,
+  getIngredientUpgradeRecipe,
+  getRecipeFromSelection,
+} from "../data/gameData";
+import type {
+  CategoryId,
+  CraftResult,
+  GameState,
+  Ingredient,
+  IngredientRank,
+  IngredientUpgradeRecipe,
+  Inventory,
+  Recipe,
+  RecipeCollectionRecord,
+  Selection,
+} from "../types/game";
 import { cloneGameState } from "./gameState";
+
+export type CraftPreview =
+  | {
+      kind: "empty";
+      message: string;
+    }
+  | {
+      kind: "invalid";
+      message: string;
+    }
+  | {
+      kind: "cupcake";
+      recipe: Recipe;
+      record: RecipeCollectionRecord | null;
+    }
+  | {
+      kind: "upgrade";
+      ingredient: Ingredient;
+      recipe: IngredientUpgradeRecipe;
+    }
+  | {
+      kind: "fallback";
+      rank: IngredientRank;
+      poolSize: number;
+      note: string;
+    };
 
 export function addIngredient(inventory: Inventory, ingredientId: string, amount = 1) {
   inventory[ingredientId] = (inventory[ingredientId] ?? 0) + amount;
@@ -85,11 +133,16 @@ export function applyIngredientReward(inventory: Inventory, ingredientIds: strin
   ingredientIds.forEach((ingredientId) => addIngredient(inventory, ingredientId, 1));
 }
 
+export function getSelectionIngredientCounts(selection: Selection) {
+  return selection.reduce<Record<string, number>>((accumulator, ingredientId) => {
+    accumulator[ingredientId] = (accumulator[ingredientId] ?? 0) + 1;
+    return accumulator;
+  }, {});
+}
+
 export function hasEnoughIngredientsForSelection(inventory: Inventory, selection: Selection) {
-  return CATEGORY_META.every(({ id }) => {
-    const ingredientId = selection[id];
-    return ingredientId !== null && (inventory[ingredientId] ?? 0) > 0;
-  });
+  const required = getSelectionIngredientCounts(selection);
+  return Object.entries(required).every(([ingredientId, amount]) => (inventory[ingredientId] ?? 0) >= amount);
 }
 
 export function getCraftedRecipePreview(selection: Selection, collection: GameState["collection"]) {
@@ -104,6 +157,114 @@ export function getCraftedRecipePreview(selection: Selection, collection: GameSt
   }
 
   return { recipe, record };
+}
+
+export function getCraftPreview(selection: Selection, collection: GameState["collection"]): CraftPreview {
+  if (selection.length === 0) {
+    return {
+      kind: "empty",
+      message: "재료를 2개 이상 고르면 자유 조합 결과를 미리 볼 수 있어요.",
+    };
+  }
+
+  if (selection.length < 2) {
+    return {
+      kind: "invalid",
+      message: "자유 조합은 재료를 최소 2개부터 넣을 수 있어요.",
+    };
+  }
+
+  if (selection.length > 5) {
+    return {
+      kind: "invalid",
+      message: "자유 조합은 한 번에 최대 5개까지만 넣을 수 있어요.",
+    };
+  }
+
+  const recipe = getFreeformCupcakeRecipe(selection);
+  if (recipe) {
+    return {
+      kind: "cupcake",
+      recipe,
+      record: collection[recipe.id] ?? null,
+    };
+  }
+
+  const upgradeRecipe = getIngredientUpgradeRecipe(selection);
+  if (upgradeRecipe) {
+    return {
+      kind: "upgrade",
+      ingredient: INGREDIENT_MAP.get(upgradeRecipe.resultIngredientId)!,
+      recipe: upgradeRecipe,
+    };
+  }
+
+  const rank = getHighestIngredientRank(selection);
+  const pool = getFallbackIngredientPool(rank);
+  if (!pool) {
+    return {
+      kind: "invalid",
+      message: "현재 선택으로는 결과 후보를 찾을 수 없어요.",
+    };
+  }
+
+  return {
+    kind: "fallback",
+    rank,
+    poolSize: pool.ingredientIds.length,
+    note: pool.note,
+  };
+}
+
+export function resolveCraftResult(selection: Selection): CraftResult | null {
+  if (selection.length < 2 || selection.length > 5) {
+    return null;
+  }
+
+  const recipe = getFreeformCupcakeRecipe(selection);
+  if (recipe) {
+    return {
+      type: "cupcake",
+      recipe,
+    };
+  }
+
+  const upgradeRecipe = getIngredientUpgradeRecipe(selection);
+  if (upgradeRecipe) {
+    const ingredient = INGREDIENT_MAP.get(upgradeRecipe.resultIngredientId);
+    if (!ingredient) {
+      return null;
+    }
+
+    return {
+      type: "ingredient",
+      ingredientId: ingredient.id,
+      ingredient,
+      rank: ingredient.rank,
+      source: "upgrade",
+      recipe: upgradeRecipe,
+    };
+  }
+
+  const rank = getHighestIngredientRank(selection);
+  const fallbackPool = getFallbackIngredientPool(rank);
+  if (!fallbackPool) {
+    return null;
+  }
+
+  const candidates = fallbackPool.ingredientIds
+    .map((ingredientId) => INGREDIENT_MAP.get(ingredientId))
+    .filter((ingredient): ingredient is Ingredient => Boolean(ingredient));
+  const ingredient = weightedPick(candidates);
+
+  return {
+    type: "ingredient",
+    ingredientId: ingredient.id,
+    ingredient,
+    rank,
+    source: "fallback",
+    recipe: null,
+  };
 }
 
 export function synchronizePendingBoxes(snapshot: GameState, now = Date.now()) {
@@ -136,7 +297,15 @@ export function getTotalInventoryCount(inventory: Inventory) {
 }
 
 export function getSelectedCount(selection: Selection) {
-  return CATEGORY_META.filter(({ id }) => Boolean(selection[id])).length;
+  return selection.length;
+}
+
+export function getSelectedCategoryCount(selection: Selection) {
+  return new Set(
+    selection
+      .map((ingredientId) => INGREDIENT_MAP.get(ingredientId)?.category)
+      .filter((category): category is CategoryId => Boolean(category)),
+  ).size;
 }
 
 export function getCategoryTotal(inventory: Inventory, categoryId: CategoryId) {
@@ -165,4 +334,8 @@ export function getDiscoveryProgressPercent(discoveredCount: number, totalCount:
   }
 
   return Math.round((discoveredCount / totalCount) * 100);
+}
+
+export function getRankLabel(rank: IngredientRank) {
+  return INGREDIENT_RANK_META[rank].label;
 }

--- a/src/lib/gameState.test.ts
+++ b/src/lib/gameState.test.ts
@@ -3,7 +3,7 @@ import { RECIPES } from "../data/gameData";
 import { createInitialGameState, exportGameState, importGameState, normalizeGameState } from "./gameState";
 
 describe("save transfer", () => {
-  it("round-trips an exported save", async () => {
+  it("round-trips an exported save with the latest mix result", async () => {
     const recipeId = RECIPES[0].id;
     const state = createInitialGameState(123);
 
@@ -13,6 +13,8 @@ describe("save transfer", () => {
     state.dailyStreak = 3;
     state.lastDailyChallengeDate = "2026-04-06";
     state.lastCraftedRecipeId = recipeId;
+    state.lastMixResult = { type: "cupcake", recipeId };
+    state.selection = ["vanilla-cloud", "milk-cloud"];
     state.discoveredRecipeIds = [recipeId];
     state.favorites = [recipeId];
     state.collection[recipeId] = {
@@ -25,6 +27,32 @@ describe("save transfer", () => {
     const imported = await importGameState(exported, 999);
 
     expect(imported).toEqual(normalizeGameState(state, 999));
+  });
+
+  it("migrates legacy slot selection objects into freeform selections", () => {
+    const state = normalizeGameState(
+      {
+        inventory: {},
+        selection: {
+          batter: "vanilla-cloud",
+          cream: "milk-cloud",
+          topping: "cherry-bloom",
+          finisher: "pink-ribbon",
+        },
+        discoveredRecipeIds: [],
+        collection: {},
+        favorites: [],
+        pendingBoxes: 0,
+        lastDeliveryResolvedAt: 0,
+        lastDailyClaimDate: "",
+        dailyStreak: 0,
+        lastDailyChallengeDate: "",
+        lastCraftedRecipeId: null,
+      },
+      0,
+    );
+
+    expect(state.selection).toEqual(["vanilla-cloud", "milk-cloud", "cherry-bloom", "pink-ribbon"]);
   });
 
   it("rejects malformed transfer strings", async () => {

--- a/src/lib/gameState.ts
+++ b/src/lib/gameState.ts
@@ -1,6 +1,6 @@
 import { MAX_PENDING_BOXES, SHOWCASE_LIMIT, STORAGE_KEY } from "../config/game";
-import { ALL_INGREDIENTS, RECIPES } from "../data/gameData";
-import type { GameState, RecipeCollectionRecord, Selection } from "../types/game";
+import { ALL_INGREDIENTS, CATEGORY_META, INGREDIENT_MAP, RECIPES } from "../data/gameData";
+import type { GameState, LastMixResult, RecipeCollectionRecord, Selection } from "../types/game";
 
 const STARTER_ITEMS: Array<[string, number]> = [
   ["vanilla-cloud", 2],
@@ -15,7 +15,7 @@ const STARTER_ITEMS: Array<[string, number]> = [
 
 const SAVE_TRANSFER_PREFIX = "daily-cupcake-save";
 const SAVE_TRANSFER_VERSION = 1;
-const REQUIRED_GAME_STATE_KEYS: Array<keyof GameState> = [
+const REQUIRED_GAME_STATE_KEYS: Array<Exclude<keyof GameState, "lastMixResult">> = [
   "inventory",
   "selection",
   "discoveredRecipeIds",
@@ -29,19 +29,9 @@ const REQUIRED_GAME_STATE_KEYS: Array<keyof GameState> = [
   "lastCraftedRecipeId",
 ];
 
-const VALID_SELECTION_VALUES = {
-  batter: new Set(ALL_INGREDIENTS.filter((ingredient) => ingredient.category === "batter").map((ingredient) => ingredient.id)),
-  cream: new Set(ALL_INGREDIENTS.filter((ingredient) => ingredient.category === "cream").map((ingredient) => ingredient.id)),
-  topping: new Set(ALL_INGREDIENTS.filter((ingredient) => ingredient.category === "topping").map((ingredient) => ingredient.id)),
-  finisher: new Set(ALL_INGREDIENTS.filter((ingredient) => ingredient.category === "finisher").map((ingredient) => ingredient.id)),
-} satisfies Record<keyof Selection, Set<string>>;
+const VALID_INGREDIENT_IDS = new Set(ALL_INGREDIENTS.map((ingredient) => ingredient.id));
 
-export const DEFAULT_SELECTION: Selection = {
-  batter: null,
-  cream: null,
-  topping: null,
-  finisher: null,
-};
+export const DEFAULT_SELECTION: Selection = [];
 
 type SaveTransferPayload = {
   format: string;
@@ -121,6 +111,59 @@ function validateSaveTransferPayload(payload: unknown): asserts payload is SaveT
   }
 }
 
+function normalizeSelection(rawSelection: unknown): Selection {
+  if (Array.isArray(rawSelection)) {
+    return rawSelection
+      .filter((ingredientId): ingredientId is string => typeof ingredientId === "string" && VALID_INGREDIENT_IDS.has(ingredientId))
+      .slice(0, 5);
+  }
+
+  if (!isRecord(rawSelection)) {
+    return [...DEFAULT_SELECTION];
+  }
+
+  return CATEGORY_META.flatMap(({ id }) => {
+    const ingredientId = rawSelection[id];
+    return typeof ingredientId === "string" && VALID_INGREDIENT_IDS.has(ingredientId) ? [ingredientId] : [];
+  });
+}
+
+function normalizeLastMixResult(rawValue: unknown, validRecipeIds: Set<string>): LastMixResult | null {
+  if (!isRecord(rawValue) || typeof rawValue.type !== "string") {
+    return null;
+  }
+
+  if (rawValue.type === "cupcake") {
+    return typeof rawValue.recipeId === "string" && validRecipeIds.has(rawValue.recipeId)
+      ? {
+          type: "cupcake",
+          recipeId: rawValue.recipeId,
+        }
+      : null;
+  }
+
+  if (
+    rawValue.type === "ingredient" &&
+    typeof rawValue.ingredientId === "string" &&
+    VALID_INGREDIENT_IDS.has(rawValue.ingredientId) &&
+    (rawValue.source === "upgrade" || rawValue.source === "fallback")
+  ) {
+    const ingredient = INGREDIENT_MAP.get(rawValue.ingredientId);
+    if (!ingredient) {
+      return null;
+    }
+
+    return {
+      type: "ingredient",
+      ingredientId: ingredient.id,
+      rank: ingredient.rank,
+      source: rawValue.source,
+    };
+  }
+
+  return null;
+}
+
 export function clamp(value: number, minimum: number, maximum: number) {
   return Math.min(maximum, Math.max(minimum, value));
 }
@@ -128,7 +171,7 @@ export function clamp(value: number, minimum: number, maximum: number) {
 function createBaseGameState(now = Date.now()): GameState {
   return {
     inventory: {},
-    selection: { ...DEFAULT_SELECTION },
+    selection: [...DEFAULT_SELECTION],
     discoveredRecipeIds: [],
     collection: {},
     favorites: [],
@@ -138,6 +181,7 @@ function createBaseGameState(now = Date.now()): GameState {
     dailyStreak: 0,
     lastDailyChallengeDate: "",
     lastCraftedRecipeId: null,
+    lastMixResult: null,
   };
 }
 
@@ -149,10 +193,11 @@ export function cloneGameState(state: GameState): GameState {
   return {
     ...state,
     inventory: { ...state.inventory },
-    selection: { ...state.selection },
+    selection: [...state.selection],
     discoveredRecipeIds: [...state.discoveredRecipeIds],
     collection,
     favorites: [...state.favorites],
+    lastMixResult: state.lastMixResult ? { ...state.lastMixResult } : null,
   };
 }
 
@@ -181,25 +226,7 @@ export function normalizeGameState(rawState: unknown, now = Date.now()): GameSta
     ]),
   );
 
-  const rawSelection = isRecord(rawState.selection) ? rawState.selection : {};
-  normalized.selection = {
-    batter:
-      typeof rawSelection.batter === "string" && VALID_SELECTION_VALUES.batter.has(rawSelection.batter)
-        ? rawSelection.batter
-        : null,
-    cream:
-      typeof rawSelection.cream === "string" && VALID_SELECTION_VALUES.cream.has(rawSelection.cream)
-        ? rawSelection.cream
-        : null,
-    topping:
-      typeof rawSelection.topping === "string" && VALID_SELECTION_VALUES.topping.has(rawSelection.topping)
-        ? rawSelection.topping
-        : null,
-    finisher:
-      typeof rawSelection.finisher === "string" && VALID_SELECTION_VALUES.finisher.has(rawSelection.finisher)
-        ? rawSelection.finisher
-        : null,
-  };
+  normalized.selection = normalizeSelection(rawState.selection);
 
   const validRecipeIds = new Set(RECIPES.map((recipe) => recipe.id));
   normalized.discoveredRecipeIds = Array.isArray(rawState.discoveredRecipeIds)
@@ -244,6 +271,14 @@ export function normalizeGameState(rawState: unknown, now = Date.now()): GameSta
     typeof rawState.lastCraftedRecipeId === "string" && validRecipeIds.has(rawState.lastCraftedRecipeId)
       ? rawState.lastCraftedRecipeId
       : null;
+  normalized.lastMixResult = normalizeLastMixResult(rawState.lastMixResult, validRecipeIds);
+
+  if (!normalized.lastMixResult && normalized.lastCraftedRecipeId) {
+    normalized.lastMixResult = {
+      type: "cupcake",
+      recipeId: normalized.lastCraftedRecipeId,
+    };
+  }
 
   return normalized;
 }

--- a/src/pages/BakeryPage.tsx
+++ b/src/pages/BakeryPage.tsx
@@ -3,10 +3,17 @@ import ovenStage from "../../assets/images/oven-stage.png";
 import { useShallow } from "zustand/react/shallow";
 import { CupcakeArt } from "../components/CupcakeArt";
 import { Tag } from "../components/Tag";
-import { CATEGORY_META, INGREDIENT_GROUPS, INGREDIENT_MAP, RECIPES, getRecipeFromSelection } from "../data/gameData";
+import {
+  CATEGORY_META,
+  INGREDIENT_GROUPS,
+  INGREDIENT_MAP,
+  INGREDIENT_RANK_META,
+  RECIPE_MAP,
+} from "../data/gameData";
 import {
   getCategoryTotal,
-  getCraftedRecipePreview,
+  getCraftPreview,
+  getSelectedCategoryCount,
   getSelectedCount,
   getTopInventoryIngredients,
   hasEnoughIngredientsForSelection,
@@ -17,11 +24,10 @@ export function BakeryPage() {
   const {
     inventory,
     selection,
-    discoveredRecipeIds,
+    craftMessage,
     collection,
     favorites,
-    craftMessage,
-    lastCraftedRecipeId,
+    lastMixResult,
     toggleSelection,
     clearSelection,
     craftCupcake,
@@ -30,11 +36,10 @@ export function BakeryPage() {
     useShallow((state) => ({
       inventory: state.inventory,
       selection: state.selection,
-      discoveredRecipeIds: state.discoveredRecipeIds,
+      craftMessage: state.craftMessage,
       collection: state.collection,
       favorites: state.favorites,
-      craftMessage: state.craftMessage,
-      lastCraftedRecipeId: state.lastCraftedRecipeId,
+      lastMixResult: state.lastMixResult,
       toggleSelection: state.toggleSelection,
       clearSelection: state.clearSelection,
       craftCupcake: state.craftCupcake,
@@ -43,34 +48,79 @@ export function BakeryPage() {
   );
 
   const spotlightIngredients = getTopInventoryIngredients(inventory);
-  const selectedRecipe = getRecipeFromSelection(selection);
-  const craftedSelectionPreview = getCraftedRecipePreview(selection, collection);
+  const selectedIngredients = selection
+    .map((ingredientId) => INGREDIENT_MAP.get(ingredientId))
+    .filter((ingredient): ingredient is NonNullable<typeof ingredient> => Boolean(ingredient));
   const selectedCount = getSelectedCount(selection);
-  const canCraft = Boolean(selectedRecipe) && hasEnoughIngredientsForSelection(inventory, selection);
-  const defaultMessage =
-    selectedCount === CATEGORY_META.length
-      ? "모든 재료가 준비됐어요. 중앙 굽기 버튼을 눌러 컵케이크를 구워 보세요."
-      : `재료 ${selectedCount}/${CATEGORY_META.length} 선택 중이에요.`;
+  const selectedCategoryCount = getSelectedCategoryCount(selection);
+  const preview = getCraftPreview(selection, collection);
+  const canCraft =
+    selectedCount >= 2 && selectedCount <= 5 && hasEnoughIngredientsForSelection(inventory, selection);
 
-  const lastCraftedRecipe = lastCraftedRecipeId
-    ? RECIPES.find((recipe) => recipe.id === lastCraftedRecipeId) ?? null
-    : null;
-  const displayedRecipe = craftedSelectionPreview?.recipe ?? lastCraftedRecipe;
-  const displayedRecipeCount =
-    craftedSelectionPreview?.record.count ??
-    (lastCraftedRecipe ? collection[lastCraftedRecipe.id]?.count ?? 0 : 0);
-  const isPreviewingKnownRecipe = Boolean(craftedSelectionPreview);
-  const isFavorite = displayedRecipe ? favorites.includes(displayedRecipe.id) : false;
+  const lastCupcake =
+    lastMixResult?.type === "cupcake" ? RECIPE_MAP.get(lastMixResult.recipeId) ?? null : null;
+  const lastIngredientResult = lastMixResult?.type === "ingredient" ? lastMixResult : null;
+  const lastIngredient =
+    lastIngredientResult ? INGREDIENT_MAP.get(lastIngredientResult.ingredientId) ?? null : null;
+  const previewFavorite = preview.kind === "cupcake" ? favorites.includes(preview.recipe.id) : false;
+  const lastCupcakeFavorite = lastCupcake ? favorites.includes(lastCupcake.id) : false;
+
+  const defaultMessage =
+    preview.kind === "empty"
+      ? preview.message
+      : preview.kind === "invalid"
+        ? preview.message
+        : preview.kind === "cupcake"
+          ? preview.record
+            ? `${preview.recipe.name} 조합은 이미 ${preview.record.count}번 성공했어요. 다시 굽거나 진열장에 올릴 수 있어요.`
+            : `${preview.recipe.name}는 아직 발견하지 못한 자유 조합 컵케이크예요.`
+          : preview.kind === "upgrade"
+            ? `${preview.ingredient.name} 재료로 승급되는 조합이에요.`
+            : `${INGREDIENT_RANK_META[preview.rank].label} 재료 후보군에서 랜덤 결과가 나와요.`;
+
+  function renderIngredientCard(
+    title: string,
+    ingredient: NonNullable<typeof lastIngredient>,
+    description: string,
+    tags: string[],
+  ) {
+    return (
+      <div
+        className="ingredient-result-card"
+        style={
+          {
+            "--ingredient-color": ingredient.color,
+            "--ingredient-accent": ingredient.accent,
+          } as CSSProperties
+        }
+      >
+        <div className="ingredient-result-card__copy">
+          <div className="section-heading">
+            <strong>{title}</strong>
+            <Tag label={INGREDIENT_RANK_META[ingredient.rank].label} bright />
+          </div>
+          <p className="ingredient-result-card__name">{ingredient.name}</p>
+          <p>{description}</p>
+          <div className="result-card__tags">
+            {tags.map((tag) => (
+              <Tag key={`${ingredient.id}-${tag}`} label={tag} />
+            ))}
+          </div>
+        </div>
+      </div>
+    );
+  }
 
   return (
     <section className="workspace panel">
       <div className="section-heading section-heading--stack">
         <div>
           <p className="eyebrow">굽기 공간</p>
-          <h2>재료 확인과 컵케이크 굽기</h2>
+          <h2>2개에서 5개까지 자유롭게 섞기</h2>
         </div>
         <span className="section-heading__note">
-          보유 재료를 확인하고, 필요한 조합만 골라 바로 굽는 페이지예요.
+          기존 고정 슬롯 대신 원하는 재료를 2~5개까지 골라 하나의 조합으로 만들어요. 같은 재료는 한 번씩만
+          선택할 수 있어요.
         </span>
       </div>
 
@@ -79,27 +129,23 @@ export function BakeryPage() {
           <div className="subpanel-heading">
             <div>
               <p className="eyebrow">보유 재료</p>
-              <h3>지금 쓸 수 있는 재료</h3>
+              <h3>지금 조합에 넣을 수 있는 재료</h3>
             </div>
             <span className="subpanel-heading__note">
-              카테고리별 수량과 자주 쓰는 재료를 먼저 확인해 보세요.
+              카테고리별 총량을 확인하고, 아래 보드에서 자유롭게 여러 재료를 골라 보세요.
             </span>
           </div>
 
           <div className="inventory-category-totals">
             {CATEGORY_META.map(({ id, label }) => {
-              const availableKinds = INGREDIENT_GROUPS[id].filter(
-                (ingredient) => (inventory[ingredient.id] ?? 0) > 0,
-              ).length;
-              const selectedIngredient = selection[id] ? INGREDIENT_MAP.get(selection[id] as string) : null;
+              const availableKinds = INGREDIENT_GROUPS[id].filter((ingredient) => (inventory[ingredient.id] ?? 0) > 0)
+                .length;
 
               return (
                 <article key={id} className="inventory-total">
                   <span className="inventory-total__label">{label}</span>
                   <strong>{`${getCategoryTotal(inventory, id)}개`}</strong>
-                  <span className="inventory-total__sub">
-                    {`${availableKinds}종 사용 가능${selectedIngredient ? ` · ${selectedIngredient.short} 선택` : ""}`}
-                  </span>
+                  <span className="inventory-total__sub">{`${availableKinds}종 사용 가능`}</span>
                 </article>
               );
             })}
@@ -107,7 +153,7 @@ export function BakeryPage() {
 
           <div className="inventory-spotlight">
             {spotlightIngredients.length === 0 ? (
-              <div className="empty-card">재료가 비어 있어요. 배달 상자를 열어 다시 채워 보세요.</div>
+              <div className="empty-card">재료가 비어 있어요. 선물함에서 상자를 열어 다시 채워 보세요.</div>
             ) : (
               spotlightIngredients.map((ingredient) => {
                 const category = CATEGORY_META.find(({ id }) => id === ingredient.category);
@@ -128,7 +174,7 @@ export function BakeryPage() {
         <article className="soft-panel oven-stage">
           <div className="subpanel-heading">
             <div>
-              <p className="eyebrow">조합하기</p>
+              <p className="eyebrow">자유 조합</p>
               <h3>오븐 중앙</h3>
             </div>
             <button type="button" className="pixel-button pixel-button--ghost" onClick={clearSelection}>
@@ -146,101 +192,137 @@ export function BakeryPage() {
                 disabled={!canCraft}
               >
                 {canCraft
-                  ? "선택한 재료로 컵케이크 굽기"
-                  : selectedCount < CATEGORY_META.length
-                    ? `재료 ${selectedCount}/${CATEGORY_META.length} 선택`
-                    : "선택한 재료가 부족해요"}
+                  ? `선택한 ${selectedCount}개 재료로 조합하기`
+                  : selectedCount < 2
+                    ? `재료 ${selectedCount}/2+ 선택`
+                    : "선택한 재료 수량이 부족해요"}
               </button>
             </div>
 
             <div className="oven-stage__info">
               <div className="mix-preview__current">
-                <h3>현재 조합</h3>
-                <div className="selection-grid">
-                  {CATEGORY_META.map(({ id, label }) => {
-                    const ingredient = selection[id] ? INGREDIENT_MAP.get(selection[id] as string) : null;
-
-                    return (
-                      <article key={id} className={`selection-card ${ingredient ? "selection-card--filled" : ""}`}>
-                        <span className="selection-card__label">{label}</span>
-                        <strong>{ingredient ? ingredient.name : "아직 선택 안 됨"}</strong>
-                        <span className="selection-card__meta">
-                          {ingredient ? `${ingredient.short} 준비 완료` : "아래 재료 카드에서 선택해 주세요"}
-                        </span>
-                      </article>
-                    );
-                  })}
+                <div className="section-heading">
+                  <h3>현재 선택</h3>
+                  <div className="result-card__tags">
+                    <Tag label={`재료 ${selectedCount}/5`} bright />
+                    <Tag label={`카테고리 ${selectedCategoryCount}/4`} />
+                  </div>
                 </div>
 
-                <div className="selection-hint">
-                  {isPreviewingKnownRecipe && selectedRecipe ? (
-                    <>
-                      <strong>이미 시도한 정확한 조합</strong>
-                      <p>
-                        {`${selectedRecipe.name} 조합은 이전에 ${craftedSelectionPreview?.record.count ?? 0}회 성공했어요. 아래 결과 카드에서 바로 다시 확인할 수 있어요.`}
-                      </p>
-                    </>
-                  ) : selectedRecipe ? (
-                    discoveredRecipeIds.includes(selectedRecipe.id) ? (
-                      <>
-                        <strong>이미 발견한 레시피</strong>
-                        <p>
-                          {`${selectedRecipe.name} 조합은 이미 발견했지만, 지금 고른 정확한 4재료는 아직 성공 기록이 없을 수도 있어요.`}
-                        </p>
-                      </>
-                    ) : (
-                      <>
-                        <strong>아직 만들지 않은 조합</strong>
-                        <p>이 정확한 4재료 조합은 아직 성공 기록이 없어요. 굽기 전까지는 미확인 상태로 남아요.</p>
-                      </>
-                    )
-                  ) : (
-                    <>
-                      <strong>조합 중</strong>
-                      <p>4종류 재료를 모두 고르면 결과 영역에서 이미 만든 조합인지 바로 확인할 수 있어요.</p>
-                    </>
-                  )}
-                </div>
+                {selectedIngredients.length === 0 ? (
+                  <div className="empty-card">아래 재료 카드에서 원하는 재료를 눌러 자유 조합을 시작해 보세요.</div>
+                ) : (
+                  <div className="selection-basket">
+                    {selectedIngredients.map((ingredient) => (
+                      <button
+                        key={ingredient.id}
+                        type="button"
+                        className="selection-token"
+                        style={
+                          {
+                            "--ingredient-color": ingredient.color,
+                            "--ingredient-accent": ingredient.accent,
+                          } as CSSProperties
+                        }
+                        onClick={() => toggleSelection(ingredient.id)}
+                      >
+                        <span className="selection-token__name">{ingredient.name}</span>
+                        <span className="selection-token__meta">{`${ingredient.short} · 선택 해제`}</span>
+                      </button>
+                    ))}
+                  </div>
+                )}
 
                 <p className="mix-preview__message">{craftMessage || defaultMessage}</p>
               </div>
 
               <div className="mix-preview__result">
-                <h3>{isPreviewingKnownRecipe ? "이미 만든 결과 미리보기" : "방금 완성한 컵케이크"}</h3>
-                {displayedRecipe ? (
-                  <div className={`result-card ${isPreviewingKnownRecipe ? "result-card--known-selection" : ""}`}>
-                    <CupcakeArt recipe={displayedRecipe} />
+                <h3>예상 결과</h3>
+                {preview.kind === "cupcake" ? (
+                  <div className="result-card">
+                    <CupcakeArt recipe={preview.recipe} />
                     <div className="result-card__copy">
                       <div className="result-card__heading">
-                        <strong>{displayedRecipe.name}</strong>
-                        <button
-                          type="button"
-                          className="mini-button"
-                          onClick={() => toggleFavorite(displayedRecipe.id)}
-                        >
-                          {isFavorite ? "진열장에서 내리기" : "진열장에 올리기"}
-                        </button>
+                        <strong>{preview.recipe.name}</strong>
+                        {preview.record ? (
+                          <button
+                            type="button"
+                            className="mini-button"
+                            onClick={() => toggleFavorite(preview.recipe.id)}
+                          >
+                            {previewFavorite ? "진열장에서 내리기" : "진열장에 올리기"}
+                          </button>
+                        ) : null}
                       </div>
+                      <p>{preview.recipe.description}</p>
                       <div className="result-card__tags">
-                        {isPreviewingKnownRecipe ? <Tag label="이미 만든 결과" bright /> : null}
-                        <Tag label={displayedRecipe.collectionLabel} />
-                        <Tag label={displayedRecipe.rarityLabel} bright />
-                        <Tag label={`제작 ${displayedRecipeCount}회`} />
-                      </div>
-                      <p>
-                        {isPreviewingKnownRecipe
-                          ? `${displayedRecipe.description} 이 정확한 조합은 새로고침 뒤에도 같은 기록으로 다시 확인할 수 있어요.`
-                          : displayedRecipe.description}
-                      </p>
-                      <div className="result-card__tags">
-                        <Tag label={isPreviewingKnownRecipe ? "현재 선택과 일치" : "가장 최근 결과"} />
+                        <Tag label={preview.recipe.collectionLabel} />
+                        <Tag label={preview.recipe.rarityLabel} bright />
+                        <Tag label={preview.record ? `이미 제작 ${preview.record.count}회` : "새 자유 조합"} />
                       </div>
                     </div>
                   </div>
-                ) : (
-                  <div className="result-card result-card--empty">
-                    아직 굽기 결과가 없어요. 정확한 4재료를 모두 고르면 이미 만든 조합인지 먼저 보여드릴게요.
+                ) : preview.kind === "upgrade" ? (
+                  renderIngredientCard(
+                    "재료 승급 예상",
+                    preview.ingredient,
+                    preview.recipe.note,
+                    ["상위 재료", `결과 ${preview.ingredient.name}`],
+                  )
+                ) : preview.kind === "fallback" ? (
+                  <div className="ingredient-result-card ingredient-result-card--fallback">
+                    <div className="ingredient-result-card__copy">
+                      <div className="section-heading">
+                        <strong>랜덤 재료 결과</strong>
+                        <Tag label={INGREDIENT_RANK_META[preview.rank].label} bright />
+                      </div>
+                      <p>
+                        정의된 컵케이크나 승급 조합이 아니어서 {preview.poolSize}종의 {INGREDIENT_RANK_META[preview.rank].label}
+                        후보군 중 하나가 나와요.
+                      </p>
+                      <p className="ingredient-result-card__note">{preview.note}</p>
+                    </div>
                   </div>
+                ) : (
+                  <div className="result-card result-card--empty">{preview.message}</div>
+                )}
+              </div>
+
+              <div className="mix-preview__result">
+                <h3>가장 최근 결과</h3>
+                {lastCupcake ? (
+                  <div className="result-card">
+                    <CupcakeArt recipe={lastCupcake} />
+                    <div className="result-card__copy">
+                      <div className="result-card__heading">
+                        <strong>{lastCupcake.name}</strong>
+                        <button
+                          type="button"
+                          className="mini-button"
+                          onClick={() => toggleFavorite(lastCupcake.id)}
+                        >
+                          {lastCupcakeFavorite ? "진열장에서 내리기" : "진열장에 올리기"}
+                        </button>
+                      </div>
+                      <p>{lastCupcake.description}</p>
+                      <div className="result-card__tags">
+                        <Tag label={lastCupcake.collectionLabel} />
+                        <Tag label={lastCupcake.rarityLabel} bright />
+                        <Tag label={`제작 ${collection[lastCupcake.id]?.count ?? 0}회`} />
+                      </div>
+                    </div>
+                  </div>
+                ) : lastIngredient ? (
+                  renderIngredientCard(
+                    lastIngredientResult?.source === "upgrade" ? "최근 승급 결과" : "최근 랜덤 결과",
+                    lastIngredient,
+                    lastIngredientResult?.source === "upgrade"
+                      ? "정의된 승급 조합으로 얻은 상위 재료예요."
+                      : "정의되지 않은 조합에서 같은 등급 후보군으로 굴린 결과예요.",
+                    [lastIngredientResult?.source === "upgrade" ? "승급 성공" : "랜덤 fallback", lastIngredient.short],
+                  )
+                ) : (
+                  <div className="result-card result-card--empty">아직 만든 결과가 없어요. 첫 자유 조합을 시도해 보세요.</div>
                 )}
               </div>
             </div>
@@ -251,7 +333,6 @@ export function BakeryPage() {
       <div className="ingredient-board">
         {CATEGORY_META.map(({ id, label, description }) => {
           const ingredients = INGREDIENT_GROUPS[id];
-          const selectedIngredient = selection[id] ? INGREDIENT_MAP.get(selection[id] as string) : null;
           const availableKinds = ingredients.filter((ingredient) => (inventory[ingredient.id] ?? 0) > 0).length;
 
           return (
@@ -259,14 +340,15 @@ export function BakeryPage() {
               <header className="ingredient-group__header">
                 <div>
                   <h3>{label}</h3>
-                  <p>{selectedIngredient ? `${selectedIngredient.name} 선택 중` : description}</p>
+                  <p>{description}</p>
                 </div>
                 <span className="ingredient-group__status">{`${availableKinds}/${ingredients.length} 준비됨`}</span>
               </header>
               <div className="ingredient-group__grid">
                 {ingredients.map((ingredient) => {
                   const amount = inventory[ingredient.id] ?? 0;
-                  const selected = selection[id] === ingredient.id;
+                  const selected = selection.includes(ingredient.id);
+                  const maxedOut = selection.length >= 5 && !selected;
 
                   return (
                     <button
@@ -279,12 +361,14 @@ export function BakeryPage() {
                           "--ingredient-accent": ingredient.accent,
                         } as CSSProperties
                       }
-                      onClick={() => toggleSelection(id, ingredient.id)}
+                      onClick={() => toggleSelection(ingredient.id)}
                       aria-pressed={selected}
-                      disabled={amount <= 0}
+                      disabled={amount <= 0 || maxedOut}
                     >
                       <span className="ingredient-pill__name">{ingredient.name}</span>
-                      <span className="ingredient-pill__meta">{ingredient.short}</span>
+                      <span className="ingredient-pill__meta">
+                        {`${ingredient.short} · ${INGREDIENT_RANK_META[ingredient.rank].label}`}
+                      </span>
                       <span className="ingredient-pill__count">{`보유 ${amount}`}</span>
                     </button>
                   );

--- a/src/store/gameStore.ts
+++ b/src/store/gameStore.ts
@@ -1,12 +1,15 @@
 import { create } from "zustand";
 import { BOXES_PER_DAILY_GIFT, SHOWCASE_LIMIT } from "../config/game";
-import { CATEGORY_META, INGREDIENT_GROUPS, getDailyRecipe, getRecipeFromSelection } from "../data/gameData";
+import { INGREDIENT_GROUPS, getDailyRecipe } from "../data/gameData";
 import {
+  addIngredient,
   applyIngredientReward,
   generateDeliveryBox,
+  getRankLabel,
   getTodayKey,
   getYesterdayKey,
   hasEnoughIngredientsForSelection,
+  resolveCraftResult,
   subtractIngredient,
   summarizeRewards,
   synchronizePendingBoxes,
@@ -20,7 +23,7 @@ import {
   loadPersistedGameState,
   savePersistedGameState,
 } from "../lib/gameState";
-import type { CategoryId, GameState, PageId, UiState } from "../types/game";
+import type { GameState, PageId, UiState } from "../types/game";
 
 const DEFAULT_UI_STATE: UiState = {
   deliveryMessage: "처음 선물 상자 3개가 준비되어 있어요. 바로 열어서 시작해 보세요.",
@@ -37,7 +40,7 @@ export interface GameStore extends GameState, UiState {
   claimDailyGift: () => void;
   craftCupcake: () => void;
   clearSelection: () => void;
-  toggleSelection: (categoryId: CategoryId, ingredientId: string) => void;
+  toggleSelection: (ingredientId: string) => void;
   toggleFavorite: (recipeId: string) => void;
   resetGame: () => void;
 }
@@ -55,6 +58,7 @@ function pickGameState(state: GameStore): GameState {
     dailyStreak: state.dailyStreak,
     lastDailyChallengeDate: state.lastDailyChallengeDate,
     lastCraftedRecipeId: state.lastCraftedRecipeId,
+    lastMixResult: state.lastMixResult,
   };
 }
 
@@ -160,11 +164,17 @@ export const useGameStore = create<GameStore>((set, get) => ({
 
   craftCupcake: () => {
     const current = get();
-    const recipe = getRecipeFromSelection(current.selection);
 
-    if (!recipe) {
+    if (current.selection.length < 2) {
       set({
-        craftMessage: "반죽, 크림, 토핑, 마무리를 모두 골라 주세요.",
+        craftMessage: "자유 조합은 재료를 최소 2개부터 넣을 수 있어요.",
+      });
+      return;
+    }
+
+    if (current.selection.length > 5) {
+      set({
+        craftMessage: "자유 조합은 한 번에 최대 5개까지만 넣을 수 있어요.",
       });
       return;
     }
@@ -176,70 +186,122 @@ export const useGameStore = create<GameStore>((set, get) => ({
       return;
     }
 
+    const result = resolveCraftResult(current.selection);
+    if (!result) {
+      set({
+        craftMessage: "현재 조합으로는 결과를 만들 수 없어요. 다른 재료를 골라 보세요.",
+      });
+      return;
+    }
+
     const now = Date.now();
     const todayKey = getTodayKey(now);
 
     set((state) => {
       const inventory = { ...state.inventory };
-      CATEGORY_META.forEach(({ id }) => {
-        const ingredientId = state.selection[id];
-        if (ingredientId) {
-          subtractIngredient(inventory, ingredientId, 1);
-        }
+      state.selection.forEach((ingredientId) => {
+        subtractIngredient(inventory, ingredientId, 1);
       });
 
-      const firstDiscovery = !state.discoveredRecipeIds.includes(recipe.id);
-      const discoveredRecipeIds = firstDiscovery
-        ? [...state.discoveredRecipeIds, recipe.id]
-        : state.discoveredRecipeIds;
-
-      const existingRecord = state.collection[recipe.id];
-      const collection = {
-        ...state.collection,
-        [recipe.id]: {
-          count: (existingRecord?.count ?? 0) + 1,
-          firstCraftedAt: existingRecord?.firstCraftedAt ?? now,
-          lastCraftedAt: now,
-        },
-      };
-
+      let discoveredRecipeIds = state.discoveredRecipeIds;
+      let collection = state.collection;
+      let lastCraftedRecipeId = state.lastCraftedRecipeId;
+      let lastMixResult = state.lastMixResult;
       let challengeMessage = state.challengeMessage;
       let lastDailyChallengeDate = state.lastDailyChallengeDate;
+      let craftMessage = "";
 
-      if (recipe.id === getDailyRecipe(todayKey).id && state.lastDailyChallengeDate !== todayKey) {
-        const bonus = [...generateDeliveryBox(), weightedPick(INGREDIENT_GROUPS.cream).id];
-        applyIngredientReward(inventory, bonus);
-        lastDailyChallengeDate = todayKey;
-        challengeMessage = `오늘의 추천 레시피를 완성해서 보너스를 받았어요. ${summarizeRewards(bonus)}`;
+      if (result.type === "cupcake") {
+        const firstDiscovery = !state.discoveredRecipeIds.includes(result.recipe.id);
+        discoveredRecipeIds = firstDiscovery
+          ? [...state.discoveredRecipeIds, result.recipe.id]
+          : state.discoveredRecipeIds;
+
+        const existingRecord = state.collection[result.recipe.id];
+        collection = {
+          ...state.collection,
+          [result.recipe.id]: {
+            count: (existingRecord?.count ?? 0) + 1,
+            firstCraftedAt: existingRecord?.firstCraftedAt ?? now,
+            lastCraftedAt: now,
+          },
+        };
+
+        lastCraftedRecipeId = result.recipe.id;
+        lastMixResult = {
+          type: "cupcake",
+          recipeId: result.recipe.id,
+        };
+
+        if (result.recipe.id === getDailyRecipe(todayKey).id && state.lastDailyChallengeDate !== todayKey) {
+          const bonus = [...generateDeliveryBox(), weightedPick(INGREDIENT_GROUPS.cream).id];
+          applyIngredientReward(inventory, bonus);
+          lastDailyChallengeDate = todayKey;
+          challengeMessage = `오늘의 추천 레시피를 완성해서 보너스를 받았어요. ${summarizeRewards(bonus)}`;
+        }
+
+        craftMessage = firstDiscovery
+          ? `새 자유 조합 컵케이크를 발견했어요. ${result.recipe.name} 도감이 열렸어요.`
+          : `${result.recipe.name}를 다시 만들었어요. 제작 기록이 한 번 더 쌓였어요.`;
+      } else {
+        addIngredient(inventory, result.ingredientId, 1);
+        lastMixResult = {
+          type: "ingredient",
+          ingredientId: result.ingredientId,
+          rank: result.rank,
+          source: result.source,
+        };
+
+        craftMessage =
+          result.source === "upgrade"
+            ? `${result.ingredient.name} 재료로 승급됐어요. 다음 조합에 바로 다시 써 볼 수 있어요.`
+            : `정의된 조합이 없어 ${getRankLabel(result.rank)} 후보군에서 ${result.ingredient.name} 재료를 얻었어요.`;
       }
 
       return {
         inventory,
         discoveredRecipeIds,
         collection,
-        lastCraftedRecipeId: recipe.id,
+        lastCraftedRecipeId,
+        lastMixResult,
         lastDailyChallengeDate,
         challengeMessage,
-        craftMessage: firstDiscovery
-          ? `새 레시피를 발견했어요. ${recipe.name} 도감이 열렸어요.`
-          : `${recipe.name}를 다시 만들었어요. 진열장에 예쁘게 올려 보세요.`,
+        craftMessage,
       };
     });
   },
 
   clearSelection: () => {
     set({
-      selection: { ...DEFAULT_SELECTION },
+      selection: [...DEFAULT_SELECTION],
       craftMessage: "",
     });
   },
 
-  toggleSelection: (categoryId, ingredientId) => {
+  toggleSelection: (ingredientId) => {
+    const current = get();
+
+    if ((current.inventory[ingredientId] ?? 0) <= 0) {
+      return;
+    }
+
+    if (current.selection.includes(ingredientId)) {
+      set((state) => ({
+        selection: state.selection.filter((selectedId) => selectedId !== ingredientId),
+        craftMessage: "",
+      }));
+      return;
+    }
+
+    if (current.selection.length >= 5) {
+      set({
+        craftMessage: "자유 조합은 최대 5개까지만 넣을 수 있어요.",
+      });
+      return;
+    }
+
     set((state) => ({
-      selection: {
-        ...state.selection,
-        [categoryId]: state.selection[categoryId] === ingredientId ? null : ingredientId,
-      },
+      selection: [...state.selection, ingredientId],
       craftMessage: "",
     }));
   },
@@ -256,7 +318,7 @@ export const useGameStore = create<GameStore>((set, get) => ({
 
     if (favorites.size >= SHOWCASE_LIMIT) {
       set({
-        craftMessage: `진열장은 최대 ${SHOWCASE_LIMIT}종까지 올릴 수 있어요. 먼저 하나를 내려 주세요.`,
+        craftMessage: `진열장은 최대 ${SHOWCASE_LIMIT}종까지만 올릴 수 있어요. 먼저 하나를 내려 주세요.`,
       });
       return;
     }

--- a/src/styles.css
+++ b/src/styles.css
@@ -777,9 +777,34 @@ p {
   gap: 14px;
 }
 
-.mix-preview__result {
+.selection-basket {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.selection-token {
   display: grid;
-  gap: 14px;
+  gap: 4px;
+  padding: 12px 14px;
+  border: 2px solid transparent;
+  border-radius: 18px;
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.96), rgba(255, 245, 249, 0.94)) padding-box,
+    linear-gradient(135deg, var(--ingredient-accent), var(--ingredient-color)) border-box;
+  text-align: left;
+  color: var(--text);
+  box-shadow: 0 4px 0 rgba(235, 176, 201, 0.72);
+  cursor: pointer;
+}
+
+.selection-token__name {
+  font-weight: 800;
+}
+
+.selection-token__meta {
+  color: var(--text-soft);
+  font-size: 0.84rem;
 }
 
 .selection-grid {
@@ -1000,11 +1025,34 @@ p {
   min-height: 190px;
 }
 
-.result-card--known-selection {
-  border: 2px solid rgba(255, 124, 173, 0.45);
+.ingredient-result-card {
+  padding: 18px;
+  border: 2px solid transparent;
+  border-radius: 24px;
   background:
-    linear-gradient(180deg, rgba(255, 251, 216, 0.95), rgba(255, 239, 247, 0.92)),
-    var(--panel-soft);
+    linear-gradient(180deg, rgba(255, 255, 255, 0.96), rgba(255, 246, 251, 0.94)) padding-box,
+    linear-gradient(135deg, var(--ingredient-accent, rgba(239, 154, 189, 0.48)), var(--ingredient-color, rgba(255, 124, 173, 0.72))) border-box;
+}
+
+.ingredient-result-card--fallback {
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.96), rgba(255, 246, 251, 0.94)) padding-box,
+    linear-gradient(135deg, rgba(255, 214, 181, 0.94), rgba(255, 124, 173, 0.72)) border-box;
+}
+
+.ingredient-result-card__copy {
+  display: grid;
+  gap: 10px;
+}
+
+.ingredient-result-card__name {
+  font-size: 1.1rem;
+  font-weight: 800;
+}
+
+.ingredient-result-card__note {
+  color: var(--text-soft);
+  font-size: 0.92rem;
 }
 
 .result-card--empty {

--- a/src/types/game.ts
+++ b/src/types/game.ts
@@ -65,20 +65,6 @@ export interface RecipePalette {
 
 export interface Recipe {
   id: string;
-  index: number;
-  name: string;
-  description: string;
-  collection: IngredientFamily;
-  collectionLabel: string;
-  rarity: Rarity;
-  rarityLabel: string;
-  ingredientIds: Record<CategoryId, string>;
-  ingredients: Ingredient[];
-  palette: RecipePalette;
-}
-
-export interface MixingCupcakeRecipe {
-  id: string;
   name: string;
   description: string;
   collection: IngredientFamily;
@@ -105,14 +91,42 @@ export interface FallbackIngredientPool {
   note: string;
 }
 
+export interface CupcakeCraftResult {
+  type: "cupcake";
+  recipe: Recipe;
+}
+
+export interface IngredientCraftResult {
+  type: "ingredient";
+  ingredientId: string;
+  ingredient: Ingredient;
+  rank: IngredientRank;
+  source: "upgrade" | "fallback";
+  recipe: IngredientUpgradeRecipe | null;
+}
+
+export type CraftResult = CupcakeCraftResult | IngredientCraftResult;
+
 export type Inventory = Record<string, number>;
-export type Selection = Record<CategoryId, string | null>;
+export type Selection = string[];
 
 export interface RecipeCollectionRecord {
   count: number;
   firstCraftedAt: number;
   lastCraftedAt: number;
 }
+
+export type LastMixResult =
+  | {
+      type: "cupcake";
+      recipeId: string;
+    }
+  | {
+      type: "ingredient";
+      ingredientId: string;
+      rank: IngredientRank;
+      source: "upgrade" | "fallback";
+    };
 
 export interface GameState {
   inventory: Inventory;
@@ -126,6 +140,7 @@ export interface GameState {
   dailyStreak: number;
   lastDailyChallengeDate: string;
   lastCraftedRecipeId: string | null;
+  lastMixResult: LastMixResult | null;
 }
 
 export interface UiState {


### PR DESCRIPTION
## Summary
- replace fixed 4-slot crafting with freeform 2 to 5 ingredient mixing
- add explicit cupcake recipes, ingredient upgrade recipes, and rank-based fallback rewards
- update bakery UI, crafting state, and save-transfer snapshots for freeform results and migration

## Testing
- `node_modules\\.bin\\tsc.cmd --noEmit`
- `npm run build` could not complete locally because Vite/SWC native loading hit `spawn EPERM` in this sandbox
- `npm test` could not complete locally for the same sandbox-native-loader reason

Closes #10
Closes #12
Closes #13
Closes #14