### PR TITLE
[codex] fix freeform recipe lookup regression

### DIFF
--- a/src/data/gameData.ts
+++ b/src/data/gameData.ts
@@ -544,6 +544,9 @@ const INGREDIENT_UPGRADE_RECIPE_SPECS: IngredientUpgradeRecipeSpec[] = [
 
 const RECIPES: Recipe[] = FREEFORM_CUPCAKE_RECIPE_SPECS.map((spec) => buildRecipe(spec));
 const RECIPE_MAP: Map<string, Recipe> = new Map(RECIPES.map((recipe) => [recipe.id, recipe]));
+const RECIPE_MIXING_KEY_MAP: Map<string, Recipe> = new Map(
+  RECIPES.map((recipe) => [createMixingKey(recipe.ingredientIds), recipe]),
+);
 
 const INGREDIENT_UPGRADE_RECIPES: IngredientUpgradeRecipe[] = INGREDIENT_UPGRADE_RECIPE_SPECS.map((spec) =>
   buildIngredientUpgradeRecipe(spec),
@@ -577,11 +580,11 @@ function getRecipeFromSelection(selection: Selection): Recipe | null {
     return null;
   }
 
-  return RECIPE_MAP.get(createMixingKey(selection)) ?? null;
+  return RECIPE_MIXING_KEY_MAP.get(createMixingKey(selection)) ?? null;
 }
 
 function getFreeformCupcakeRecipe(ingredientIds: string[]) {
-  return RECIPE_MAP.get(createMixingKey(ingredientIds)) ?? null;
+  return RECIPE_MIXING_KEY_MAP.get(createMixingKey(ingredientIds)) ?? null;
 }
 
 function getIngredientUpgradeRecipe(ingredientIds: string[]) {


### PR DESCRIPTION
## Summary
- fix freeform cupcake lookup to use a mixing-key index instead of the recipe id map
- restore order-independent recipe matching for craft resolution and preview paths
- follow up on the post-merge CI failure from #29

## Testing
- local vitest remains blocked in this sandbox by Vite/SWC native loading (`spawn EPERM`)
- GitHub Actions should re-run the repository test suite on this PR