### PR TITLE
[codex] Redesign freeform mixing data model

### DIFF
--- a/src/data/gameData.test.ts
+++ b/src/data/gameData.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from "vitest";
+import {
+  FALLBACK_RESULT_POOLS,
+  FREEFORM_RECIPE_PROTOTYPES,
+  INGREDIENT_MAP,
+  INGREDIENT_UPGRADE_RULES,
+  buildMixKey,
+  getDominantIngredientRank,
+  getFallbackResultPoolForIngredientIds,
+  getIngredientUpgradeFromIngredientIds,
+  getRecipeFromIngredientIds,
+} from "./gameData";
+
+describe("freeform recipe data", () => {
+  it("builds order-independent mix keys", () => {
+    expect(buildMixKey(["milk-cloud", "vanilla-cloud", "pink-ribbon"])).toBe(
+      buildMixKey(["pink-ribbon", "vanilla-cloud", "milk-cloud"]),
+    );
+  });
+
+  it("keeps the current 4-slot recipe catalog accessible through ingredient arrays", () => {
+    const recipe = getRecipeFromIngredientIds([
+      "vanilla-cloud",
+      "milk-cloud",
+      "cherry-bloom",
+      "pink-ribbon",
+    ]);
+
+    expect(recipe?.id).toBe("vanilla-cloud__milk-cloud__cherry-bloom__pink-ribbon");
+    expect(recipe?.ingredientIds).toEqual([
+      "vanilla-cloud",
+      "milk-cloud",
+      "cherry-bloom",
+      "pink-ribbon",
+    ]);
+  });
+
+  it("defines prototype cupcake combos from 2 to 5 ingredients", () => {
+    const counts = FREEFORM_RECIPE_PROTOTYPES.map((prototype) => prototype.ingredientIds.length);
+
+    expect(new Set(counts)).toEqual(new Set([2, 3, 4, 5]));
+    expect(FREEFORM_RECIPE_PROTOTYPES.every((prototype) => prototype.mixKey === buildMixKey(prototype.ingredientIds))).toBe(
+      true,
+    );
+  });
+});
+
+describe("ingredient upgrade data", () => {
+  it("matches configured upgrade rules by freeform ingredient set", () => {
+    const upgrade = getIngredientUpgradeFromIngredientIds(["sparkle-sugar", "heart-sprinkle"]);
+
+    expect(upgrade?.ingredientId).toBe("stardust");
+    expect(upgrade?.resultRank).toBe(2);
+  });
+
+  it("stores upgrade rules with normalized keys", () => {
+    expect(
+      INGREDIENT_UPGRADE_RULES.every((rule) => rule.mixKey === buildMixKey(rule.ingredientIds)),
+    ).toBe(true);
+  });
+});
+
+describe("fallback rank pools", () => {
+  it("groups fallback candidates by ingredient rank", () => {
+    expect(FALLBACK_RESULT_POOLS[1].ingredientIds.every((ingredientId) => INGREDIENT_MAP.get(ingredientId)?.rank === 1)).toBe(
+      true,
+    );
+    expect(FALLBACK_RESULT_POOLS[2].ingredientIds.every((ingredientId) => INGREDIENT_MAP.get(ingredientId)?.rank === 2)).toBe(
+      true,
+    );
+  });
+
+  it("derives the dominant rank from selected ingredients", () => {
+    expect(getDominantIngredientRank(["vanilla-cloud", "milk-cloud", "sparkle-sugar"])).toBe(1);
+    expect(getDominantIngredientRank(["matcha-forest", "cream-cheese", "cookie-star"])).toBe(2);
+  });
+
+  it("returns a matching fallback pool for a mix", () => {
+    const fallback = getFallbackResultPoolForIngredientIds(["vanilla-cloud", "milk-cloud"]);
+
+    expect(fallback.rank).toBe(1);
+    expect(fallback.ingredientIds.length).toBeGreaterThan(0);
+  });
+});

--- a/src/data/gameData.ts
+++ b/src/data/gameData.ts
@@ -1,16 +1,28 @@
-// @ts-nocheck
-
 import type {
   CategoryId,
   CategoryMeta,
   CollectionMetaEntry,
+  CupcakeRecipeRule,
+  FallbackResultPool,
+  FreeformRecipePrototype,
   Ingredient,
   IngredientFamily,
+  IngredientRank,
+  IngredientRankMetaEntry,
+  IngredientUpgradeRule,
   Rarity,
   RarityMetaEntry,
   Recipe,
+  RecipePalette,
   Selection,
 } from "../types/game";
+
+type LegacyRecipeSeed = {
+  id: string;
+  ingredientIds: string[];
+};
+
+const LEGACY_CATEGORY_ORDER: CategoryId[] = ["batter", "cream", "topping", "finisher"];
 
 const BATTERS: Ingredient[] = [
   {
@@ -19,7 +31,7 @@ const BATTERS: Ingredient[] = [
     name: "바닐라 구름 반죽",
     short: "바닐라",
     family: "cloud",
-    rarity: 1,
+    rank: 1,
     dropWeight: 8,
     color: "#ffd6b5",
     accent: "#fff4de",
@@ -28,9 +40,9 @@ const BATTERS: Ingredient[] = [
     id: "choco-puff",
     category: "batter",
     name: "초코 퍼프 반죽",
-    short: "초코",
+    short: "초콈",
     family: "cocoa",
-    rarity: 1,
+    rank: 1,
     dropWeight: 8,
     color: "#c69272",
     accent: "#f2d1be",
@@ -41,7 +53,7 @@ const BATTERS: Ingredient[] = [
     name: "딸기 요정 반죽",
     short: "딸기",
     family: "berry",
-    rarity: 1,
+    rank: 1,
     dropWeight: 8,
     color: "#ff9eb5",
     accent: "#ffe3ea",
@@ -52,7 +64,7 @@ const BATTERS: Ingredient[] = [
     name: "말차 숲 반죽",
     short: "말차",
     family: "forest",
-    rarity: 2,
+    rank: 2,
     dropWeight: 5,
     color: "#b6d7a8",
     accent: "#eef7d8",
@@ -63,7 +75,7 @@ const BATTERS: Ingredient[] = [
     name: "레몬 선샤인 반죽",
     short: "레몬",
     family: "sun",
-    rarity: 2,
+    rank: 2,
     dropWeight: 5,
     color: "#ffe28a",
     accent: "#fff8cf",
@@ -75,9 +87,9 @@ const CREAMS: Ingredient[] = [
     id: "milk-cloud",
     category: "cream",
     name: "우유 구름 크림",
-    short: "우유구름",
+    short: "우유구릈",
     family: "cloud",
-    rarity: 1,
+    rank: 1,
     dropWeight: 8,
     color: "#fff7f9",
     accent: "#ffe7ef",
@@ -88,7 +100,7 @@ const CREAMS: Ingredient[] = [
     name: "딸기 버터 크림",
     short: "딸기버터",
     family: "berry",
-    rarity: 1,
+    rank: 1,
     dropWeight: 8,
     color: "#ffbdd4",
     accent: "#ffe8f1",
@@ -99,7 +111,7 @@ const CREAMS: Ingredient[] = [
     name: "크림치즈 크림",
     short: "크림치즈",
     family: "garden",
-    rarity: 2,
+    rank: 2,
     dropWeight: 5,
     color: "#fff1d6",
     accent: "#ffe1b4",
@@ -110,7 +122,7 @@ const CREAMS: Ingredient[] = [
     name: "솜사탕 크림",
     short: "솜사탕",
     family: "dream",
-    rarity: 2,
+    rank: 2,
     dropWeight: 5,
     color: "#ffd3ef",
     accent: "#dff7ff",
@@ -121,7 +133,7 @@ const CREAMS: Ingredient[] = [
     name: "카라멜 리본 크림",
     short: "카라멜",
     family: "cocoa",
-    rarity: 2,
+    rank: 2,
     dropWeight: 5,
     color: "#e6b588",
     accent: "#fff0d6",
@@ -135,7 +147,7 @@ const TOPPINGS: Ingredient[] = [
     name: "체리 블룸 토핑",
     short: "체리",
     family: "berry",
-    rarity: 1,
+    rank: 1,
     dropWeight: 8,
     color: "#ff6f91",
     accent: "#ffd9e5",
@@ -146,7 +158,7 @@ const TOPPINGS: Ingredient[] = [
     name: "하트 스프링클 토핑",
     short: "하트",
     family: "dream",
-    rarity: 1,
+    rank: 1,
     dropWeight: 8,
     color: "#ff94c2",
     accent: "#ffe7f3",
@@ -154,10 +166,10 @@ const TOPPINGS: Ingredient[] = [
   {
     id: "bunny-marshmallow",
     category: "topping",
-    name: "토끼 마시멜로 토핑",
+    name: "토끼 마시로로 토핑",
     short: "토끼",
     family: "cloud",
-    rarity: 2,
+    rank: 2,
     dropWeight: 5,
     color: "#fffdf8",
     accent: "#ffd5e9",
@@ -168,7 +180,7 @@ const TOPPINGS: Ingredient[] = [
     name: "쿠키 스타 토핑",
     short: "쿠키별",
     family: "star",
-    rarity: 2,
+    rank: 2,
     dropWeight: 5,
     color: "#d0a77d",
     accent: "#fff2cc",
@@ -179,7 +191,7 @@ const TOPPINGS: Ingredient[] = [
     name: "블루베리 진주 토핑",
     short: "블루진주",
     family: "moon",
-    rarity: 2,
+    rank: 2,
     dropWeight: 5,
     color: "#8898ff",
     accent: "#e6ebff",
@@ -190,10 +202,10 @@ const FINISHERS: Ingredient[] = [
   {
     id: "pink-ribbon",
     category: "finisher",
-    name: "분홍 리본 마무리",
+    name: "별칼 리본 마무리",
     short: "리본",
     family: "berry",
-    rarity: 1,
+    rank: 1,
     dropWeight: 8,
     color: "#ff8fb8",
     accent: "#fff0f6",
@@ -201,10 +213,10 @@ const FINISHERS: Ingredient[] = [
   {
     id: "sparkle-sugar",
     category: "finisher",
-    name: "반짝 슈가 마무리",
+    name: "반짝 수가 마무리",
     short: "반짝",
     family: "star",
-    rarity: 1,
+    rank: 1,
     dropWeight: 8,
     color: "#fff6f0",
     accent: "#ffe8aa",
@@ -215,7 +227,7 @@ const FINISHERS: Ingredient[] = [
     name: "꽃잎 캔디 마무리",
     short: "꽃잎",
     family: "garden",
-    rarity: 2,
+    rank: 2,
     dropWeight: 5,
     color: "#ffb7d2",
     accent: "#ffdff0",
@@ -226,7 +238,7 @@ const FINISHERS: Ingredient[] = [
     name: "별가루 마무리",
     short: "별가루",
     family: "moon",
-    rarity: 2,
+    rank: 2,
     dropWeight: 5,
     color: "#c3caff",
     accent: "#eef1ff",
@@ -237,7 +249,7 @@ const FINISHERS: Ingredient[] = [
     name: "허니 시럽 마무리",
     short: "허니",
     family: "sun",
-    rarity: 2,
+    rank: 2,
     dropWeight: 5,
     color: "#ffc95c",
     accent: "#fff3bc",
@@ -250,6 +262,19 @@ const CATEGORY_META: CategoryMeta[] = [
   { id: "topping", label: "토핑", description: "귀여운 장식과 포인트 토핑" },
   { id: "finisher", label: "마무리", description: "마지막 분위기를 결정하는 장식" },
 ];
+
+const INGREDIENT_RANK_META: Record<IngredientRank, IngredientRankMetaEntry> = {
+  1: {
+    label: "기본 재료",
+    accent: "#ffd7ea",
+    description: "배달 상자에서 자주 얻는 시작 등급 재료",
+  },
+  2: {
+    label: "승급 재료",
+    accent: "#ffc95c",
+    description: "특정 조합이나 높은 등급 결과에서 얻는 확장 재료",
+  },
+};
 
 const COLLECTION_META: Record<IngredientFamily, CollectionMetaEntry> = {
   berry: { label: "베리 정원", accent: "#ff8ab4" },
@@ -278,45 +303,61 @@ const INGREDIENT_GROUPS: Record<CategoryId, Ingredient[]> = {
 };
 
 const ALL_INGREDIENTS: Ingredient[] = Object.values(INGREDIENT_GROUPS).flat();
-const INGREDIENT_MAP: Map<string, Ingredient> = new Map(
-  ALL_INGREDIENTS.map((ingredient) => [ingredient.id, ingredient]),
-);
+const INGREDIENT_MAP = new Map<string, Ingredient>(ALL_INGREDIENTS.map((ingredient) => [ingredient.id, ingredient]));
 
-function pickDominantFamily(families) {
-  const familyCount = families.reduce((accumulator, family) => {
-    accumulator[family] = (accumulator[family] ?? 0) + 1;
+function countFamilies(ingredients: Ingredient[]) {
+  return ingredients.reduce<Partial<Record<IngredientFamily, number>>>((accumulator, ingredient) => {
+    accumulator[ingredient.family] = (accumulator[ingredient.family] ?? 0) + 1;
     return accumulator;
   }, {});
+}
 
-  return Object.entries(familyCount).sort((left, right) => {
+function sortByCategoryOrder(ingredients: Ingredient[]) {
+  return [...ingredients].sort(
+    (left, right) =>
+      LEGACY_CATEGORY_ORDER.indexOf(left.category) - LEGACY_CATEGORY_ORDER.indexOf(right.category),
+  );
+}
+
+function sortForTitle(ingredients: Ingredient[]) {
+  const finisher = ingredients.find((ingredient) => ingredient.category === "finisher");
+  const cream = ingredients.find((ingredient) => ingredient.category === "cream");
+  const batter = ingredients.find((ingredient) => ingredient.category === "batter");
+  const topping = ingredients.find((ingredient) => ingredient.category === "topping");
+
+  const ordered = [finisher, cream, batter, topping].filter(
+    (ingredient): ingredient is Ingredient => Boolean(ingredient),
+  );
+
+  return ordered.length > 0 ? ordered : ingredients;
+}
+
+function pickDominantFamily(ingredients: Ingredient[]): IngredientFamily {
+  const familyCount = countFamilies(ingredients);
+  const rankedFamilies = Object.entries(familyCount) as Array<[IngredientFamily, number]>;
+
+  rankedFamilies.sort((left, right) => {
     if (right[1] !== left[1]) {
       return right[1] - left[1];
     }
+
     return left[0].localeCompare(right[0], "ko");
-  })[0][0];
+  });
+
+  return rankedFamilies[0]?.[0] ?? "cloud";
 }
 
-function computeRarityScore(parts) {
-  const baseScore = parts.reduce((sum, item) => sum + item.rarity, 0);
-  let synergy = 0;
+function computeRarityScore(ingredients: Ingredient[]) {
+  const baseScore = ingredients.reduce((sum, ingredient) => sum + ingredient.rank, 0);
+  const familyCount = Object.values(countFamilies(ingredients));
+  const dominantFamilyBonus = familyCount.length > 0 ? Math.max(...familyCount) - 1 : 0;
+  const duplicateCategoryBonus =
+    ingredients.length - new Set(ingredients.map((ingredient) => ingredient.category)).size;
 
-  if (parts[0].family === parts[1].family) {
-    synergy += 2;
-  }
-  if (parts[2].family === parts[3].family) {
-    synergy += 2;
-  }
-
-  const familyCount = parts.reduce((accumulator, item) => {
-    accumulator[item.family] = (accumulator[item.family] ?? 0) + 1;
-    return accumulator;
-  }, {});
-
-  synergy += Math.max(...Object.values(familyCount)) - 1;
-  return baseScore + synergy;
+  return baseScore + dominantFamilyBonus + duplicateCategoryBonus;
 }
 
-function classifyRarity(score) {
+function classifyRarity(score: number): Rarity {
   if (score >= 10) {
     return "legendary";
   }
@@ -329,93 +370,282 @@ function classifyRarity(score) {
   return "common";
 }
 
-function buildRecipeDescription(batter, cream, topping, finisher, collectionLabel) {
-  return `${batter.name} 위에 ${cream.name}을 풍성하게 올리고 ${topping.name}와 ${finisher.name}로 마무리한 ${collectionLabel} 시그니처 컵케이크.`;
+function buildRecipeTitle(ingredients: Ingredient[]) {
+  return `${sortForTitle(ingredients)
+    .map((ingredient) => ingredient.short)
+    .join(" ")} 컵케이크`;
 }
 
-function buildRecipeTitle(batter, cream, topping, finisher) {
-  return `${finisher.short} ${cream.short} ${batter.short} ${topping.short} 컵케이크`;
+function buildRecipeDescription(ingredients: Ingredient[], collectionLabel: string) {
+  return `${ingredients.map((ingredient) => ingredient.name).join(", ")} 조합으砜 완성한 ${collectionLabel} 시그니처 컵케이크.`;
 }
 
-function buildRecipes() {
-  const recipes = [];
-  let index = 0;
+function getIngredientOrThrow(ingredientId: string) {
+  const ingredient = INGREDIENT_MAP.get(ingredientId);
+  if (!ingredient) {
+    throw new Error(`Unknown ingredient: ${ingredientId}`);
+  }
 
-  BATTERS.forEach((batter) => {
-    CREAMS.forEach((cream) => {
-      TOPPINGS.forEach((topping) => {
-        FINISHERS.forEach((finisher) => {
-          const parts = [batter, cream, topping, finisher];
-          const dominantFamily = pickDominantFamily(parts.map((item) => item.family));
-          const collection = COLLECTION_META[dominantFamily];
-          const rarityScore = computeRarityScore(parts);
-          const rarity = classifyRarity(rarityScore);
+  return ingredient;
+}
 
-          recipes.push({
+function getIngredientsOrThrow(ingredientIds: string[]) {
+  return ingredientIds.map((ingredientId) => getIngredientOrThrow(ingredientId));
+}
+
+function buildRecipePalette(ingredients: Ingredient[], rarity: Rarity, collection: IngredientFamily): RecipePalette {
+  const batter = ingredients.find((ingredient) => ingredient.category === "batter") ?? ingredients[0];
+  const cream = ingredients.find((ingredient) => ingredient.category === "cream") ?? ingredients[1] ?? batter;
+  const topping =
+    ingredients.find((ingredient) => ingredient.category === "topping") ?? ingredients[2] ?? cream;
+  const finisher =
+    ingredients.find((ingredient) => ingredient.category === "finisher") ?? ingredients[3] ?? topping;
+
+  return {
+    wrapper: batter.accent,
+    cake: batter.color,
+    cream: cream.color,
+    frostingAccent: cream.accent,
+    topping: topping.color,
+    topperAccent: topping.accent,
+    finish: finisher.color,
+    finishAccent: finisher.accent,
+    rarity: RARITY_META[rarity].accent,
+    collection: COLLECTION_META[collection].accent,
+  };
+}
+
+function buildMixKey(ingredientIds: string[]) {
+  return [...ingredientIds].sort((left, right) => left.localeCompare(right, "en")).join("__");
+}
+
+function createRecipe(seed: LegacyRecipeSeed, index: number): Recipe {
+  const ingredients = getIngredientsOrThrow(seed.ingredientIds);
+  const collection = pickDominantFamily(ingredients);
+  const rarity = classifyRarity(computeRarityScore(ingredients));
+
+  return {
+    id: seed.id,
+    index,
+    name: buildRecipeTitle(ingredients),
+    description: buildRecipeDescription(ingredients, COLLECTION_META[collection].label),
+    collection,
+    collectionLabel: COLLECTION_META[collection].label,
+    rarity,
+    rarityLabel: RARITY_META[rarity].label,
+    ingredientIds: [...seed.ingredientIds],
+    mixKey: buildMixKey(seed.ingredientIds),
+    ingredients: sortByCategoryOrder(ingredients),
+    palette: buildRecipePalette(ingredients, rarity, collection),
+  };
+}
+
+function buildLegacyRecipeSeeds() {
+  const seeds: LegacyRecipeSeed[] = [];
+
+  for (const batter of BATTERS) {
+    for (const cream of CREAMS) {
+      for (const topping of TOPPINGS) {
+        for (const finisher of FINISHERS) {
+          seeds.push({
             id: `${batter.id}__${cream.id}__${topping.id}__${finisher.id}`,
-            index,
-            name: buildRecipeTitle(batter, cream, topping, finisher),
-            description: buildRecipeDescription(
-              batter,
-              cream,
-              topping,
-              finisher,
-              collection.label,
-            ),
-            collection: dominantFamily,
-            collectionLabel: collection.label,
-            rarity,
-            rarityLabel: RARITY_META[rarity].label,
-            ingredientIds: {
-              batter: batter.id,
-              cream: cream.id,
-              topping: topping.id,
-              finisher: finisher.id,
-            },
-            ingredients: parts,
-            palette: {
-              wrapper: batter.accent,
-              cake: batter.color,
-              cream: cream.color,
-              frostingAccent: cream.accent,
-              topping: topping.color,
-              topperAccent: topping.accent,
-              finish: finisher.color,
-              finishAccent: finisher.accent,
-              rarity: RARITY_META[rarity].accent,
-              collection: collection.accent,
-            },
+            ingredientIds: [batter.id, cream.id, topping.id, finisher.id],
           });
+        }
+      }
+    }
+  }
 
-          index += 1;
-        });
-      });
-    });
-  });
-
-  return recipes;
+  return seeds;
 }
 
-const RECIPES: Recipe[] = buildRecipes();
-const RECIPE_MAP: Map<string, Recipe> = new Map(RECIPES.map((recipe) => [recipe.id, recipe]));
+const RECIPES: Recipe[] = buildLegacyRecipeSeeds().map((seed, index) => createRecipe(seed, index));
+const RECIPE_MAP = new Map<string, Recipe>(RECIPES.map((recipe) => [recipe.id, recipe]));
+
+const CUPCAKE_RECIPE_RULES: CupcakeRecipeRule[] = RECIPES.map((recipe) => ({
+  id: recipe.id,
+  ingredientIds: [...recipe.ingredientIds],
+  mixKey: recipe.mixKey,
+  resultType: "cupcake",
+  recipeId: recipe.id,
+}));
+
+const CUPCAKE_RECIPE_RULE_MAP = new Map<string, CupcakeRecipeRule>(
+  CUPCAKE_RECIPE_RULES.map((rule) => [rule.mixKey, rule]),
+);
+
+const FREEFORM_RECIPE_PROTOTYPES: FreeformRecipePrototype[] = [
+  {
+    id: "berry-duet",
+    name: "딸기 리본 듀엣 컵케이크",
+    ingredientIds: ["strawberry-fairy", "strawberry-butter"],
+    mixKey: buildMixKey(["strawberry-fairy", "strawberry-butter"]),
+    notes: "2재료 조합도 데이터로 표현할 수 있게 두 재료 레시피 예시를 추가한다.",
+  },
+  {
+    id: "cloud-promenade",
+    name: "구름 산책 컵케이크",
+    ingredientIds: ["vanilla-cloud", "milk-cloud", "bunny-marshmallow"],
+    mixKey: buildMixKey(["vanilla-cloud", "milk-cloud", "bunny-marshmallow"]),
+    notes: "3재료 조합에서 같은 테마 재료가 이어지는 구조 예시다.",
+  },
+  {
+    id: "twilight-library",
+    name: "황혼 서고 컵케이크",
+    ingredientIds: ["choco-puff", "caramel-ribbon", "cookie-star", "stardust"],
+    mixKey: buildMixKey(["choco-puff", "caramel-ribbon", "cookie-star", "stardust"]),
+    notes: "현재 4파트 구조와 호환되는 자유 조합 레시피 예시다.",
+  },
+  {
+    id: "festival-medley",
+    name: "축제 메들리 컵케이크",
+    ingredientIds: [
+      "strawberry-fairy",
+      "milk-cloud",
+      "heart-sprinkle",
+      "pink-ribbon",
+      "sparkle-sugar",
+    ],
+    mixKey: buildMixKey([
+      "strawberry-fairy",
+      "milk-cloud",
+      "heart-sprinkle",
+      "pink-ribbon",
+      "sparkle-sugar",
+    ]),
+    notes: "5재료 조합과 중복 카테고리 입력을 함께 표현하는 예시다.",
+  },
+];
+
+const INGREDIENT_UPGRADE_RULES: IngredientUpgradeRule[] = [
+  {
+    id: "upgrade-cream-cheese",
+    ingredientIds: ["vanilla-cloud", "milk-cloud"],
+    mixKey: buildMixKey(["vanilla-cloud", "milk-cloud"]),
+    resultType: "ingredient",
+    ingredientId: "cream-cheese",
+    resultRank: 2,
+  },
+  {
+    id: "upgrade-bunny-marshmallow",
+    ingredientIds: ["vanilla-cloud", "milk-cloud", "pink-ribbon"],
+    mixKey: buildMixKey(["vanilla-cloud", "milk-cloud", "pink-ribbon"]),
+    resultType: "ingredient",
+    ingredientId: "bunny-marshmallow",
+    resultRank: 2,
+  },
+  {
+    id: "upgrade-cotton-candy",
+    ingredientIds: ["vanilla-cloud", "heart-sprinkle", "pink-ribbon"],
+    mixKey: buildMixKey(["vanilla-cloud", "heart-sprinkle", "pink-ribbon"]),
+    resultType: "ingredient",
+    ingredientId: "cotton-candy",
+    resultRank: 2,
+  },
+  {
+    id: "upgrade-cookie-star",
+    ingredientIds: ["choco-puff", "heart-sprinkle", "sparkle-sugar"],
+    mixKey: buildMixKey(["choco-puff", "heart-sprinkle", "sparkle-sugar"]),
+    resultType: "ingredient",
+    ingredientId: "cookie-star",
+    resultRank: 2,
+  },
+  {
+    id: "upgrade-flower-candy",
+    ingredientIds: ["strawberry-fairy", "strawberry-butter", "pink-ribbon"],
+    mixKey: buildMixKey(["strawberry-fairy", "strawberry-butter", "pink-ribbon"]),
+    resultType: "ingredient",
+    ingredientId: "flower-candy",
+    resultRank: 2,
+  },
+  {
+    id: "upgrade-stardust",
+    ingredientIds: ["heart-sprinkle", "sparkle-sugar"],
+    mixKey: buildMixKey(["heart-sprinkle", "sparkle-sugar"]),
+    resultType: "ingredient",
+    ingredientId: "stardust",
+    resultRank: 2,
+  },
+];
+
+const INGREDIENT_UPGRADE_RULE_MAP = new Map<string, IngredientUpgradeRule>(
+  INGREDIENT_UPGRADE_RULES.map((rule) => [rule.mixKey, rule]),
+);
+
+const FALLBACK_RESULT_POOLS: Record<IngredientRank, FallbackResultPool> = {
+  1: {
+    rank: 1,
+    ingredientIds: ALL_INGREDIENTS.filter((ingredient) => ingredient.rank === 1).map((ingredient) => ingredient.id),
+  },
+  2: {
+    rank: 2,
+    ingredientIds: ALL_INGREDIENTS.filter((ingredient) => ingredient.rank === 2).map((ingredient) => ingredient.id),
+  },
+};
+
+function getIngredientIdsFromSelection(selection: Selection) {
+  return LEGACY_CATEGORY_ORDER.flatMap((categoryId) => {
+    const ingredientId = selection[categoryId];
+    return ingredientId ? [ingredientId] : [];
+  });
+}
 
 function getRecipeIdFromSelection(selection: Selection) {
-  if (!selection.batter || !selection.cream || !selection.topping || !selection.finisher) {
+  const ingredientIds = getIngredientIdsFromSelection(selection);
+  if (ingredientIds.length !== LEGACY_CATEGORY_ORDER.length) {
     return null;
   }
 
-  return `${selection.batter}__${selection.cream}__${selection.topping}__${selection.finisher}`;
+  return getRecipeFromIngredientIds(ingredientIds)?.id ?? null;
 }
 
 function getRecipeFromSelection(selection: Selection): Recipe | null {
-  const recipeId = getRecipeIdFromSelection(selection);
-  return recipeId ? RECIPE_MAP.get(recipeId) ?? null : null;
+  const ingredientIds = getIngredientIdsFromSelection(selection);
+  if (ingredientIds.length !== LEGACY_CATEGORY_ORDER.length) {
+    return null;
+  }
+
+  return getRecipeFromIngredientIds(ingredientIds);
 }
 
-function hashString(value) {
-  return Array.from(value).reduce((hash, character) => {
-    return (hash * 31 + character.charCodeAt(0)) % 2147483647;
-  }, 7);
+function getRecipeFromIngredientIds(ingredientIds: string[]) {
+  const mixKey = buildMixKey(ingredientIds);
+  const rule = CUPCAKE_RECIPE_RULE_MAP.get(mixKey);
+
+  return rule ? RECIPE_MAP.get(rule.recipeId) ?? null : null;
+}
+
+function getIngredientUpgradeFromIngredientIds(ingredientIds: string[]) {
+  return INGREDIENT_UPGRADE_RULE_MAP.get(buildMixKey(ingredientIds)) ?? null;
+}
+
+function getIngredientRankById(ingredientId: string) {
+  return INGREDIENT_MAP.get(ingredientId)?.rank ?? null;
+}
+
+function getDominantIngredientRank(ingredientIds: string[]): IngredientRank {
+  const ranks = ingredientIds
+    .map((ingredientId) => getIngredientRankById(ingredientId))
+    .filter((rank): rank is IngredientRank => rank !== null);
+
+  if (ranks.length === 0) {
+    return 1;
+  }
+
+  const averageRank = ranks.reduce((sum, rank) => sum + rank, 0) / ranks.length;
+  return averageRank >= 1.5 ? 2 : 1;
+}
+
+function getFallbackResultPoolByRank(rank: IngredientRank) {
+  return FALLBACK_RESULT_POOLS[rank];
+}
+
+function getFallbackResultPoolForIngredientIds(ingredientIds: string[]) {
+  return getFallbackResultPoolByRank(getDominantIngredientRank(ingredientIds));
+}
+
+function hashString(value: string) {
+  return Array.from(value).reduce((hash, character) => (hash * 31 + character.charCodeAt(0)) % 2147483647, 7);
 }
 
 function getDailyRecipe(dateKey: string): Recipe {
@@ -425,18 +655,30 @@ function getDailyRecipe(dateKey: string): Recipe {
 
 export {
   ALL_INGREDIENTS,
+  BATTERS,
   CATEGORY_META,
   COLLECTION_META,
+  CREAMS,
+  CUPCAKE_RECIPE_RULES,
+  FALLBACK_RESULT_POOLS,
   FINISHERS,
+  FREEFORM_RECIPE_PROTOTYPES,
   INGREDIENT_GROUPS,
   INGREDIENT_MAP,
+  INGREDIENT_RANK_META,
+  INGREDIENT_UPGRADE_RULES,
   RARITY_META,
   RECIPES,
   RECIPE_MAP,
   TOPPINGS,
-  BATTERS,
-  CREAMS,
+  buildMixKey,
   getDailyRecipe,
+  getDominantIngredientRank,
+  getFallbackResultPoolByRank,
+  getFallbackResultPoolForIngredientIds,
+  getIngredientRankById,
+  getIngredientUpgradeFromIngredientIds,
+  getRecipeFromIngredientIds,
   getRecipeFromSelection,
   getRecipeIdFromSelection,
 };

--- a/src/types/game.ts
+++ b/src/types/game.ts
@@ -1,4 +1,5 @@
 export type CategoryId = "batter" | "cream" | "topping" | "finisher";
+export type IngredientRank = 1 | 2;
 
 export type IngredientFamily =
   | "berry"
@@ -12,7 +13,6 @@ export type IngredientFamily =
   | "moon";
 
 export type Rarity = "common" | "rare" | "epic" | "legendary";
-
 export type PageId = "home" | "bakery" | "delivery" | "collection" | "showcase";
 
 export interface Ingredient {
@@ -21,10 +21,16 @@ export interface Ingredient {
   name: string;
   short: string;
   family: IngredientFamily;
-  rarity: number;
+  rank: IngredientRank;
   dropWeight: number;
   color: string;
   accent: string;
+}
+
+export interface IngredientRankMetaEntry {
+  label: string;
+  accent: string;
+  description: string;
 }
 
 export interface CategoryMeta {
@@ -65,13 +71,45 @@ export interface Recipe {
   collectionLabel: string;
   rarity: Rarity;
   rarityLabel: string;
-  ingredientIds: Record<CategoryId, string>;
+  ingredientIds: string[];
+  mixKey: string;
   ingredients: Ingredient[];
   palette: RecipePalette;
 }
 
+export interface CupcakeRecipeRule {
+  id: string;
+  ingredientIds: string[];
+  mixKey: string;
+  resultType: "cupcake";
+  recipeId: string;
+}
+
+export interface IngredientUpgradeRule {
+  id: string;
+  ingredientIds: string[];
+  mixKey: string;
+  resultType: "ingredient";
+  ingredientId: string;
+  resultRank: IngredientRank;
+}
+
+export interface FallbackResultPool {
+  rank: IngredientRank;
+  ingredientIds: string[];
+}
+
+export interface FreeformRecipePrototype {
+  id: string;
+  name: string;
+  ingredientIds: string[];
+  mixKey: string;
+  notes: string;
+}
+
 export type Inventory = Record<string, number>;
 export type Selection = Record<CategoryId, string | null>;
+export type MixSelection = string[];
 
 export interface RecipeCollectionRecord {
   count: number;


### PR DESCRIPTION
## What changed
- replace fixed-slot recipe metadata with freeform ingredient arrays and normalized mix keys
- add ingredient rank, upgrade rule, fallback pool, and prototype recipe data for the upcoming freeform crafting flow
- add focused data tests that cover mix-key normalization, upgrade lookups, and fallback rank grouping

## Why
Issue #11 is the data-model foundation for the freeform mixing system. The app still keeps the current selection UI, but recipe and ingredient data are now shaped so issues #12 and #13 can switch runtime logic and UI without another schema rewrite.

## Validation
- `node node_modules/typescript/bin/tsc --noEmit`
- `npm test` (blocked in this sandbox by Vite `spawn EPERM` during config load)
- `npm run build` (blocked in this sandbox by Vite `spawn EPERM` during config load)

Closes #11